### PR TITLE
Update log4j.xml

### DIFF
--- a/xxl-job-executor-example/src/main/resources/log4j.xml
+++ b/xxl-job-executor-example/src/main/resources/log4j.xml
@@ -11,8 +11,6 @@
 	
     <appender name="FILE" class="org.apache.log4j.DailyRollingFileAppender">
         <param name="file" value="/data/applogs/xxl-job/xxl-job-executor-example.log"/>
-        <param name="append" value="true"/>
-        <param name="encoding" value="UTF-8"/>
         <layout class="org.apache.log4j.PatternLayout">
             <param name="ConversionPattern" value="%-d{yyyy-MM-dd HH:mm:ss} xxl-job-executor-example [%c]-[%t]-[%M]-[%L]-[%p] %m%n"/>
         </layout>
@@ -20,19 +18,12 @@
     
     <appender name="xxl-job" class="com.xxl.job.core.log.XxlJobFileAppender">
         <param name="filePath" value="/data/applogs/xxl-job/jobhandler/"/>
-        <param name="append" value="true"/>
-        <param name="encoding" value="UTF-8"/>
         <layout class="org.apache.log4j.PatternLayout">
             <param name="ConversionPattern" value="%-d{yyyy-MM-dd HH:mm:ss} xxl-job-executor-example [%c]-[%t]-[%M]-[%L]-[%p] %m%n"/>
         </layout>
     </appender>
     
-    <root>
-        <level value="INFO" />
-        <appender-ref ref="CONSOLE" />
-        <appender-ref ref="FILE" />
-        <appender-ref ref="xxl-job"/>
-    </root>
+    
     <logger name="com.xxl.job.core" additivity="false">
     	<level value="INFO" />
         <appender-ref ref="CONSOLE" />
@@ -45,6 +36,13 @@
         <appender-ref ref="FILE" />
         <appender-ref ref="xxl-job"/>
     </logger>
+	
+    <root>
+        <level value="INFO" />
+        <appender-ref ref="CONSOLE" />
+        <appender-ref ref="FILE" />
+        <appender-ref ref="xxl-job"/>
+    </root>	
     
     
 </log4j:configuration>


### PR DESCRIPTION
当部署在tomcat中时 有下面的警告

log4j:WARN The content of element type "log4j:configuration" must match "(renderer*,throwableRenderer?,appender*,plugin*,(category|logger)*,root?,(categoryFactory|loggerFactory)?)".
log4j:WARN No such property [append] in com.xxl.job.core.log.XxlJobFileAppender.
log4j:WARN No such property [encoding] in com.xxl.job.core.log.XxlJobFileAppender.

做了上述修改后 可以去除这些警告