### PR TITLE
添加指定注册Host,主要是为容器做支持，支持k8s通过Service Name访问

### DIFF
--- a/xxl-job-admin/Dockerfile
+++ b/xxl-job-admin/Dockerfile
@@ -1,0 +1,3 @@
+FROM tomcat:latest
+MAINTAINER "icyblazek@gamil.com"
+ADD target/xxl-job-admin-1.8.2-SNAPSHOT.war /usr/local/tomcat/webapps/xxl-job-admin.war

--- a/xxl-job-core/src/main/java/com/xxl/job/core/executor/XxlJobExecutor.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/executor/XxlJobExecutor.java
@@ -33,6 +33,7 @@ public class XxlJobExecutor implements ApplicationContextAware {
     private String adminAddresses;
     private String accessToken;
     private String logPath;
+    private String registryHost;
 
     public void setIp(String ip) {
         this.ip = ip;
@@ -52,6 +53,7 @@ public class XxlJobExecutor implements ApplicationContextAware {
     public void setLogPath(String logPath) {
         this.logPath = logPath;
     }
+    public void setRegistryHost(String registryHost) { this.registryHost = registryHost; }
 
 
     // ---------------------- applicationContext ----------------------
@@ -81,7 +83,11 @@ public class XxlJobExecutor implements ApplicationContextAware {
         }
 
         // init executor-server
-        initExecutorServer(port, ip, appName, accessToken);
+        if (registryHost != null && registryHost.length() > 0){
+            initExecutorServer(port, ip, appName, accessToken, registryHost);
+        }else {
+            initExecutorServer(port, ip, appName, accessToken);
+        }
     }
     public void destroy(){
         // destory JobThreadRepository
@@ -125,6 +131,13 @@ public class XxlJobExecutor implements ApplicationContextAware {
         NetComServerFactory.setAccessToken(accessToken);
         serverFactory.start(port, ip, appName); // jetty + registry
     }
+
+    private void initExecutorServer(int port, String ip, String appName, String accessToken, String registryHost) throws Exception {
+        NetComServerFactory.putService(ExecutorBiz.class, new ExecutorBizImpl());   // rpc-service, base on jetty
+        NetComServerFactory.setAccessToken(accessToken);
+        serverFactory.start(port, ip, appName, registryHost); // jetty + registry
+    }
+
     private void stopExecutorServer() {
         serverFactory.destroy();    // jetty + registry + callback
     }

--- a/xxl-job-core/src/main/java/com/xxl/job/core/rpc/netcom/NetComServerFactory.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/rpc/netcom/NetComServerFactory.java
@@ -25,6 +25,12 @@ public class NetComServerFactory  {
 		server.start(port, ip, appName);
 	}
 
+	public void start(int port, String ip, String appName, String registryHost) throws Exception {
+		server.start(port, ip, appName, registryHost);
+	}
+
+
+
 	// ---------------------- server destroy ----------------------
 	public void destroy(){
 		server.destroy();

--- a/xxl-job-core/src/main/java/com/xxl/job/core/rpc/netcom/jetty/server/JettyServer.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/rpc/netcom/jetty/server/JettyServer.java
@@ -21,6 +21,10 @@ public class JettyServer {
 	private Server server;
 	private Thread thread;
 	public void start(final int port, final String ip, final String appName) throws Exception {
+		this.start(port, ip, appName, null);
+	}
+
+	public void start(final int port, final String ip, final String appName, final String registryHost) throws Exception {
 		thread = new Thread(new Runnable() {
 			@Override
 			public void run() {
@@ -47,7 +51,7 @@ public class JettyServer {
 					logger.info(">>>>>>>>>>>> xxl-job jetty server start success at port:{}.", port);
 
 					// Start Registry-Server
-					ExecutorRegistryThread.getInstance().start(port, ip, appName);
+					ExecutorRegistryThread.getInstance().start(port, ip, appName, registryHost);
 
 					// Start Callback-Server
 					TriggerCallbackThread.getInstance().start();

--- a/xxl-job-core/src/main/java/com/xxl/job/core/thread/ExecutorRegistryThread.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/thread/ExecutorRegistryThread.java
@@ -25,6 +25,10 @@ public class ExecutorRegistryThread extends Thread {
     private Thread registryThread;
     private volatile boolean toStop = false;
     public void start(final int port, final String ip, final String appName){
+        this.start(port, ip, appName, null);
+    }
+
+    public void start(final int port, final String ip, final String appName, final String registryHost){
 
         // valid
         if (appName==null || appName.trim().length()==0) {
@@ -38,10 +42,14 @@ public class ExecutorRegistryThread extends Thread {
 
         // executor address (generate addredd = ip:port)
         final String executorAddress;
-        if (ip != null && ip.trim().length()>0) {
-            executorAddress = ip.trim().concat(":").concat(String.valueOf(port));
-        } else {
-            executorAddress = IpUtil.getIpPort(port);
+        if (registryHost != null && registryHost.length() > 0){
+            executorAddress = registryHost;
+        }else {
+            if (ip != null && ip.trim().length()>0) {
+                executorAddress = ip.trim().concat(":").concat(String.valueOf(port));
+            } else {
+                executorAddress = IpUtil.getIpPort(port);
+            }
         }
 
         registryThread = new Thread(new Runnable() {


### PR DESCRIPTION
**问题：**
xxx-job-admin和executor在k8s集群下，由于容器的IP是动态的，在注册执行器里，手动填写IP变得不大可能，当然可以通过NodePort或者EndPoint绑定在固定的IP上，但这样管理很不便。

当executor 不指定ip地址地，executor自动获取IP地址，第一次执行正常，但后面再次执行时就会出现如下错误，xxx-job-admin一直在处理于等待状态，无法继续执行。
`[Thread-5] INFO  c.x.j.c.t.ExecutorRegistryThread - >>>>>>>>>>> xxl-job registry fail, registryParam:RegistryParam{registGroup='EXECUTOR', registryKey='com.icyblazek.test', registryValue='10.8.46.18:9998'}, registryResult:ReturnT [code=500, msg=The timestamp difference between admin and executor exceeds the limit., content=null]`

**使用**
`
XxlJobExecutor xxlJobExecutor = new XxlJobExecutor();
xxlJobExecutor.setIp(ip);
xxlJobExecutor.setPort(port);
// 通过这里设置，这里可以设置为在k8s内部的service name
xxlJobExecutor.setRegistryHost(registryHost);
`
再次执行时，能够正常注册
`xxl-job registry success, registryParam:RegistryParam{registGroup='EXECUTOR', registryKey='com.icyblazek.test', registryValue='mko-service-task-creator'}, registryResult:ReturnT [code=200, msg=null, content=null]`

**其它**
关于集群，如果我使用k8s的集群，及同时注册为同一个Service Name，xxl-job-admin不知道将如何调度，有时间去验证一下。