### PR TITLE
修正xxl-job.xml端口自动获取的描述和执行器在指定ip自动获取端口时的错误

### DIFF
--- a/xxl-job-core/src/main/java/com/xxl/job/core/executor/XxlJobExecutor.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/executor/XxlJobExecutor.java
@@ -129,7 +129,7 @@ public class XxlJobExecutor implements ApplicationContextAware {
     private NetComServerFactory serverFactory = new NetComServerFactory();
     private void initExecutorServer(int port, String ip, String appName, String accessToken) throws Exception {
         // valid param
-        port = port>0?port: NetUtil.findAvailablePort(9999);
+        port = port>0?port: NetUtil.findAvailablePort(9999,ip);
 
         // start server
         NetComServerFactory.putService(ExecutorBiz.class, new ExecutorBizImpl());   // rpc-service, base on jetty

--- a/xxl-job-core/src/main/java/com/xxl/job/core/util/NetUtil.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/util/NetUtil.java
@@ -2,8 +2,10 @@ package com.xxl.job.core.util;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.util.StringUtils;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 
 /**
@@ -15,23 +17,24 @@ public class NetUtil {
     private static Logger logger = LoggerFactory.getLogger(NetUtil.class);
 
     /**
-     * find avaliable port
+     * find avaliable port by ip
      *
      * @param defaultPort
+     * @param ip
      * @return
      */
-    public static int findAvailablePort(int defaultPort) {
+    public static int findAvailablePort(int defaultPort,String ip) {
         int portTmp = defaultPort;
         while (portTmp < 65535) {
-            if (!isPortUsed(portTmp)) {
+            if (!isPortUsed(portTmp,ip)) {
                 return portTmp;
             } else {
                 portTmp++;
             }
         }
-        portTmp = defaultPort--;
+        portTmp = --defaultPort;
         while (portTmp > 0) {
-            if (!isPortUsed(portTmp)) {
+            if (!isPortUsed(portTmp,ip)) {
                 return portTmp;
             } else {
                 portTmp--;
@@ -41,17 +44,33 @@ public class NetUtil {
     }
 
     /**
+     * find avaliable port
+     *
+     * @param defaultPort
+     * @return
+     */
+    public static int findAvailablePort(int defaultPort) {
+        return findAvailablePort(defaultPort,null);
+    }
+
+
+    /**
      * check port used
      *
      * @param port
+     * @param ip 为空则为 InetAddress.anyLocalAddress()
      * @return
      */
-    public static boolean isPortUsed(int port) {
+    public static boolean isPortUsed(int port,String ip) {
         boolean used = false;
         ServerSocket serverSocket = null;
         try {
-            serverSocket = new ServerSocket(port);
-            used = false;
+            if(StringUtils.isEmpty(ip)){
+                serverSocket = new ServerSocket(port);
+            }else {
+                serverSocket = new ServerSocket();
+                serverSocket.bind(new InetSocketAddress(ip,port));
+            }
         } catch (IOException e) {
             logger.debug(">>>>>>>>>>> xxl-job, port[{}] is in use.", port);
             used = true;

--- a/xxl-job-executor-samples/xxl-job-executor-sample-spring/src/main/resources/applicationcontext-xxl-job.xml
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-spring/src/main/resources/applicationcontext-xxl-job.xml
@@ -29,7 +29,7 @@
 		<property name="appName" value="${xxl.job.executor.appname}" />
 		<!-- 执行器IP[选填]，为空则自动获取 -->
 		<property name="ip" value="${xxl.job.executor.ip}" />
-		<!-- 执行器端口号[选填]，为空则自动获取 -->
+		<!-- 执行器端口号[选填]，为<0则自动获取 -->
 		<property name="port" value="${xxl.job.executor.port}" />
 		<!-- 访问令牌[选填]，非空则进行匹配校验 -->
 		<property name="accessToken" value="${xxl.job.accessToken}" />


### PR DESCRIPTION
1.修正xml配置文件描述信息 int类型不允许xml为空的配置会报NPE
2.修复指定执行器ip时自动获取端口号的问题，指定ip与InetAddress.anyLocalAddress()结果不一致会导致验证端口是否使用错误。

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**


**Other information:**