### PR TITLE
日志回退到以前版本

### DIFF
--- a/xxl-job-core/src/main/java/com/xxl/job/core/log/XxlJobLogger.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/log/XxlJobLogger.java
@@ -1,14 +1,13 @@
 package com.xxl.job.core.log;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.helpers.FormattingTuple;
-import org.slf4j.helpers.MessageFormatter;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.text.MessageFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 /**
  * Created by xuxueli on 17/4/28.
@@ -55,15 +54,12 @@ public class XxlJobLogger {
      */
     public static void log(String appendLogPattern, Object ... appendLogArguments) {
 
-    	FormattingTuple ft = MessageFormatter.format(appendLogPattern, appendLogArguments);
-        
-        String appendLog = ft.getMessage();
+        String appendLog = appendLogPattern;
+        if (appendLogArguments!=null && appendLogArguments.length>0) {
+            appendLog = MessageFormat.format(appendLogPattern, appendLogArguments);
+        }
+
         StackTraceElement callInfo = new Throwable().getStackTrace()[1];
-        
-//        appendLog = appendLogPattern;
-//        if (appendLogArguments!=null && appendLogArguments.length>0) {
-//            appendLog = MessageFormat.format(appendLogPattern, appendLogArguments);
-//        }
         logDetail(callInfo, appendLog);
     }
 


### PR DESCRIPTION
上次提交时，由于当时打印日志格式为： (参数{},"参数一")的不支持，所以修改日志支持这种格式。
但是由于日志本身已支持：(参数{0},"参数一")，此次修改会导致老用户在更新后程序打印日志参数时，无法显示出参数，所以这次修改回来，以后在提交时会做更多验证，保证严谨


