### PR TITLE
开发时，使用maven carge插件来运行admin程序: mvn cargo:run。相关文档：https://codehaus-ca…

### DIFF
--- a/xxl-job-admin/pom.xml
+++ b/xxl-job-admin/pom.xml
@@ -143,4 +143,13 @@
 
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.cargo</groupId>
+				<artifactId>cargo-maven2-plugin</artifactId>
+				<version>1.6.8</version>
+			</plugin>
+		</plugins>
+	</build>
 </project>


### PR DESCRIPTION
开发时，还要手工copy war或者需要设置IDE，觉得有些麻烦。所以加一个cargo 插件，这样就方便了，对新人来说，运行admin，只需要初始化mysql，再执行 mvn cargo:run ，最后访问 localhost:8080 就可以了打开admin页面了。

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [*] Build-related changes

- [ ] Other, please describe:


**The description of the PR:**


**Other information:**