### PR TITLE
扩展NetComClientProxy方式的API接口，支持任务的新增、修改、删除、挂起和恢复

### DIFF
--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobInfo.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobInfo.java
@@ -1,5 +1,6 @@
 package com.xxl.job.admin.core.model;
 
+import java.io.Serializable;
 import java.util.Date;
 
 /**
@@ -7,7 +8,7 @@ import java.util.Date;
  *
  * @author xuxueli  2016-1-12 18:25:49
  */
-public class XxlJobInfo {
+public class XxlJobInfo implements Serializable {
 	
 	private int id;				// 主键ID	    (JobKey.name)
 	

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/schedule/XxlJobDynamicScheduler.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/schedule/XxlJobDynamicScheduler.java
@@ -10,6 +10,7 @@ import com.xxl.job.admin.dao.XxlJobGroupDao;
 import com.xxl.job.admin.dao.XxlJobInfoDao;
 import com.xxl.job.admin.dao.XxlJobLogDao;
 import com.xxl.job.admin.dao.XxlJobRegistryDao;
+import com.xxl.job.admin.service.ApiAdminBiz;
 import com.xxl.job.core.biz.AdminBiz;
 import com.xxl.job.core.biz.ExecutorBiz;
 import com.xxl.job.core.enums.ExecutorBlockStrategyEnum;
@@ -56,6 +57,7 @@ public final class XxlJobDynamicScheduler implements ApplicationContextAware {
     public static XxlJobRegistryDao xxlJobRegistryDao;
     public static XxlJobGroupDao xxlJobGroupDao;
     public static AdminBiz adminBiz;
+    public static ApiAdminBiz apiAdminBiz;
 
     // ---------------------- applicationContext ----------------------
     @Override
@@ -65,6 +67,7 @@ public final class XxlJobDynamicScheduler implements ApplicationContextAware {
         XxlJobDynamicScheduler.xxlJobRegistryDao = applicationContext.getBean(XxlJobRegistryDao.class);
         XxlJobDynamicScheduler.xxlJobGroupDao = applicationContext.getBean(XxlJobGroupDao.class);
         XxlJobDynamicScheduler.adminBiz = applicationContext.getBean(AdminBiz.class);
+        XxlJobDynamicScheduler.apiAdminBiz = applicationContext.getBean(ApiAdminBiz.class);
 	}
 
     // ---------------------- init + destroy ----------------------
@@ -77,6 +80,7 @@ public final class XxlJobDynamicScheduler implements ApplicationContextAware {
 
         // admin-server(spring-mvc)
         NetComServerFactory.putService(AdminBiz.class, XxlJobDynamicScheduler.adminBiz);
+        NetComServerFactory.putService(ApiAdminBiz.class, XxlJobDynamicScheduler.adminBiz);
         NetComServerFactory.setAccessToken(accessToken);
 
         // init i18n

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/service/ApiAdminBiz.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/service/ApiAdminBiz.java
@@ -1,0 +1,52 @@
+package com.xxl.job.admin.service;
+
+import com.xxl.job.admin.core.model.XxlJobInfo;
+import com.xxl.job.core.biz.AdminBiz;
+import com.xxl.job.core.biz.model.ReturnT;
+
+/**
+ * 提供API管理端接口
+ *
+ * @author caiyihua
+ */
+public interface ApiAdminBiz extends AdminBiz {
+    /**
+     * 新增调度任务
+     *
+     * @param jobInfo
+     * @return
+     */
+    ReturnT<String> add(XxlJobInfo jobInfo);
+
+    /**
+     * 修改调度任务
+     *
+     * @param jobInfo
+     * @return
+     */
+    ReturnT<String> update(XxlJobInfo jobInfo);
+
+    /**
+     * 删除调度任务
+     *
+     * @param id
+     * @return
+     */
+    ReturnT<String> remove(int id);
+
+    /**
+     * 暂停调度任务
+     *
+     * @param id
+     * @return
+     */
+    ReturnT<String> pause(int id);
+
+    /**
+     * 恢复调度任务
+     *
+     * @param id
+     * @return
+     */
+    ReturnT<String> resume(int id);
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/service/impl/ApiAdminBizImpl.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/service/impl/ApiAdminBizImpl.java
@@ -1,0 +1,41 @@
+package com.xxl.job.admin.service.impl;
+
+import com.xxl.job.admin.core.model.XxlJobInfo;
+import com.xxl.job.admin.service.ApiAdminBiz;
+import com.xxl.job.admin.service.XxlJobService;
+import com.xxl.job.core.biz.model.ReturnT;
+import javax.annotation.Resource;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+
+@Service
+@Primary
+public class ApiAdminBizImpl extends AdminBizImpl implements ApiAdminBiz {
+    @Resource
+    private XxlJobService xxlJobService;
+
+    @Override
+    public ReturnT<String> add(XxlJobInfo jobInfo) {
+        return xxlJobService.add(jobInfo);
+    }
+
+    @Override
+    public ReturnT<String> update(XxlJobInfo jobInfo) {
+        return xxlJobService.update(jobInfo);
+    }
+
+    @Override
+    public ReturnT<String> remove(int id) {
+        return xxlJobService.remove(id);
+    }
+
+    @Override
+    public ReturnT<String> pause(int id) {
+        return xxlJobService.pause(id);
+    }
+
+    @Override
+    public ReturnT<String> resume(int id) {
+        return xxlJobService.resume(id);
+    }
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/service/impl/XxlJobServiceImpl.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/service/impl/XxlJobServiceImpl.java
@@ -130,7 +130,7 @@ public class XxlJobServiceImpl implements XxlJobService {
         try {
             XxlJobDynamicScheduler.addJob(qz_name, qz_group, jobInfo.getJobCron());
             //XxlJobDynamicScheduler.pauseJob(qz_name, qz_group);
-            return ReturnT.SUCCESS;
+            return new ReturnT<>(jobInfo.getId()+"");
         } catch (SchedulerException e) {
             logger.error(e.getMessage(), e);
             try {

--- a/xxl-job-admin/src/main/resources/log4j.xml
+++ b/xxl-job-admin/src/main/resources/log4j.xml
@@ -10,7 +10,7 @@
 	</appender>
 	
     <appender name="FILE" class="org.apache.log4j.DailyRollingFileAppender">
-        <param name="file" value="/data/applogs/xxl-job/xxl-job-admin.log"/>
+        <param name="file" value="./xxl-job/xxl-job-admin.log"/>
         <param name="append" value="true"/>
         <param name="encoding" value="UTF-8"/>
         <layout class="org.apache.log4j.PatternLayout">

--- a/xxl-job-admin/src/main/resources/xxl-job-admin.properties
+++ b/xxl-job-admin/src/main/resources/xxl-job-admin.properties
@@ -1,16 +1,16 @@
 ### xxl-job db  (use &amp; replace & in xml)
 xxl.job.db.driverClass=com.mysql.jdbc.Driver
-xxl.job.db.url=jdbc:mysql://localhost:3306/xxl-job?useUnicode=true&characterEncoding=UTF-8
+xxl.job.db.url=jdbc:mysql://192.168.0.248:3306/xxl-job?useUnicode=true&characterEncoding=UTF-8
 xxl.job.db.user=root
-xxl.job.db.password=root_pwd
+xxl.job.db.password=a+rquQe5KMGKKkmFJkl0
 
 ### xxl-job email
-xxl.job.mail.host=smtp.163.com
-xxl.job.mail.port=25
+xxl.job.mail.host=smtp.exmail.qq.com
+xxl.job.mail.port=465
 xxl.job.mail.ssl=false
-xxl.job.mail.username=ovono802302@163.com
-xxl.job.mail.password=asdfzxcv
-xxl.job.mail.sendNick=《任务调度平台XXL-JOB》
+xxl.job.mail.username=alert@wcansoft.com
+xxl.job.mail.password=Wcansoft123
+xxl.job.mail.sendNick=WCAN XXL-JOB
 
 ### xxl-job login
 xxl.job.login.username=admin

--- a/xxl-job-admin/src/main/resources/xxl-job-admin.properties
+++ b/xxl-job-admin/src/main/resources/xxl-job-admin.properties
@@ -1,16 +1,16 @@
 ### xxl-job db  (use &amp; replace & in xml)
 xxl.job.db.driverClass=com.mysql.jdbc.Driver
-xxl.job.db.url=jdbc:mysql://192.168.0.248:3306/xxl-job?useUnicode=true&characterEncoding=UTF-8
+xxl.job.db.url=jdbc:mysql://localhost:3306/xxl-job?useUnicode=true&characterEncoding=UTF-8
 xxl.job.db.user=root
-xxl.job.db.password=a+rquQe5KMGKKkmFJkl0
+xxl.job.db.password=root_pwd
 
 ### xxl-job email
-xxl.job.mail.host=smtp.exmail.qq.com
-xxl.job.mail.port=465
+xxl.job.mail.host=smtp.163.com
+xxl.job.mail.port=25
 xxl.job.mail.ssl=false
-xxl.job.mail.username=alert@wcansoft.com
-xxl.job.mail.password=Wcansoft123
-xxl.job.mail.sendNick=WCAN XXL-JOB
+xxl.job.mail.username=ovono802302@163.com
+xxl.job.mail.password=asdfzxcv
+xxl.job.mail.sendNick=《任务调度平台XXL-JOB》
 
 ### xxl-job login
 xxl.job.login.username=admin

--- a/xxl-job-admin/src/test/java/com/xxl/job/admin/service/ApiAdminBizTest.java
+++ b/xxl-job-admin/src/test/java/com/xxl/job/admin/service/ApiAdminBizTest.java
@@ -1,0 +1,85 @@
+package com.xxl.job.admin.service;
+
+import com.xxl.job.admin.core.model.XxlJobInfo;
+import com.xxl.job.core.biz.AdminBiz;
+import com.xxl.job.core.biz.model.ReturnT;
+import com.xxl.job.core.rpc.netcom.NetComClientProxy;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ApiAdminBizTest {
+    // admin-client
+    private static String addressUrl = "http://127.0.0.1:8080".concat(AdminBiz.MAPPING);
+    private static String accessToken = null;
+
+    @Test
+    public void add() throws Exception {
+        ApiAdminBiz apiAdminBiz = (ApiAdminBiz) new NetComClientProxy(ApiAdminBiz.class, addressUrl, accessToken)
+                .getObject();
+
+        XxlJobInfo xxlJobInfo = new XxlJobInfo();
+        xxlJobInfo.setAlarmEmail("caiyihua@wcansoft.com");
+        xxlJobInfo.setAuthor("Cai Yihua");
+        xxlJobInfo.setExecutorBlockStrategy("SERIAL_EXECUTION");
+        xxlJobInfo.setExecutorHandler("demoJobHandler");
+        xxlJobInfo.setExecutorFailRetryCount(0);
+        xxlJobInfo.setExecutorParam("");
+        xxlJobInfo.setExecutorRouteStrategy("FIRST");
+        xxlJobInfo.setExecutorTimeout(0);
+        xxlJobInfo.setJobCron("0 0/3 * * * ? ");
+        xxlJobInfo.setJobGroup(13);
+        xxlJobInfo.setJobDesc("API测试任务");
+        xxlJobInfo.setGlueType("BEAN");
+        ReturnT<String> returnT = apiAdminBiz.add(xxlJobInfo);
+        Assert.assertTrue(returnT.getCode() == ReturnT.SUCCESS_CODE);
+    }
+
+    @Test
+    public void update() throws Exception {
+        ApiAdminBiz apiAdminBiz = (ApiAdminBiz) new NetComClientProxy(ApiAdminBiz.class, addressUrl, accessToken)
+                .getObject();
+        XxlJobInfo xxlJobInfo = new XxlJobInfo();
+        xxlJobInfo.setId(34);
+        xxlJobInfo.setExecutorRouteStrategy("FIRST");
+        xxlJobInfo.setExecutorBlockStrategy("SERIAL_EXECUTION");
+        xxlJobInfo.setJobCron("0 0/3 * * * ? ");
+        xxlJobInfo.setJobDesc("我是修改备注");
+        xxlJobInfo.setAuthor("Cai Yihua");
+        ReturnT<String> returnT = apiAdminBiz.update(xxlJobInfo);
+        Assert.assertTrue(returnT.getCode() == ReturnT.SUCCESS_CODE);
+    }
+
+    @Test
+    public void remove() throws Exception {
+        ApiAdminBiz apiAdminBiz = (ApiAdminBiz) new NetComClientProxy(ApiAdminBiz.class, addressUrl, accessToken)
+                .getObject();
+        ReturnT<String> returnT = apiAdminBiz.remove(34);
+        Assert.assertTrue(returnT.getCode() == ReturnT.SUCCESS_CODE);
+    }
+
+    @Test
+    public void pause() throws Exception {
+        ApiAdminBiz apiAdminBiz = (ApiAdminBiz) new NetComClientProxy(ApiAdminBiz.class, addressUrl, accessToken)
+                .getObject();
+        ReturnT<String> returnT = apiAdminBiz.pause(34);
+        Assert.assertTrue(returnT.getCode() == ReturnT.SUCCESS_CODE);
+    }
+
+    @Test
+    public void resume() throws Exception {
+        ApiAdminBiz apiAdminBiz = (ApiAdminBiz) new NetComClientProxy(ApiAdminBiz.class, addressUrl, accessToken)
+                .getObject();
+        ReturnT<String> returnT = apiAdminBiz.resume(34);
+        Assert.assertTrue(returnT.getCode() == ReturnT.SUCCESS_CODE);
+    }
+
+    @Test
+    public void triggerJob() throws Exception {
+        ApiAdminBiz apiAdminBiz = (ApiAdminBiz) new NetComClientProxy(ApiAdminBiz.class, addressUrl, accessToken)
+                .getObject();
+
+        int jobId = 34;
+        ReturnT<String> returnT = apiAdminBiz.triggerJob(jobId);
+        Assert.assertTrue(returnT.getCode() == ReturnT.SUCCESS_CODE);
+    }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [] Feature
扩展XXL JOB对API接口的支持。目前支持任务的新增、修改、删除、挂起和恢复。

**The description of the PR:**
项目中需要通过代码来调用XXL JOB的API来动态操作任务。目前最新的1.9.2版本中已经提供了一个API---触发任务，但是这个接口还不能满足我们的项目需求，所以我在XXL JOB现有API实现机制上扩展了接口实现。增量代码比较少，尽量沿用了XXL JOB原有设计。

**Other information:**
我觉得当前实现还不是最优解。最好的办法是把XxlJobGroup和XxlJobInfo实体类迁移到xxl-core, 直接把新增的接口加到AdminBiz中，这样最好的遵循原有的设计，也方便API调用者使用，只需要依赖xxl-core一个jar即可。
