### PR TITLE
新增Job接口需要返回Job ID

### DIFF
--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/service/impl/XxlJobServiceImpl.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/service/impl/XxlJobServiceImpl.java
@@ -130,7 +130,7 @@ public class XxlJobServiceImpl implements XxlJobService {
         try {
             XxlJobDynamicScheduler.addJob(qz_name, qz_group, jobInfo.getJobCron());
             //XxlJobDynamicScheduler.pauseJob(qz_name, qz_group);
-            return ReturnT.SUCCESS;
+            return new ReturnT<>(qz_name);
         } catch (SchedulerException e) {
             logger.error(e.getMessage(), e);
             try {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Feature
新增Job这个接口需要能返回新Job ID给接口调用者，因为业务系统需要记录这个ID方便后续的修改、删除、暂停、恢复或触发操作。如果新增接口不返回JOB ID, 后续接口都无法使用了。


**The description of the PR:**


**Other information:**