### PR TITLE
IpUtil获取本地地址的bug

### DIFF
--- a/xxl-job-core/src/main/java/com/xxl/job/core/util/IpUtil.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/util/IpUtil.java
@@ -1,13 +1,16 @@
 package com.xxl.job.core.util;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
+import java.net.SocketException;
 import java.net.UnknownHostException;
+import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * get ip
@@ -42,15 +45,6 @@ public class IpUtil {
 	 * @return
 	 */
 	private static InetAddress getFirstValidAddress() {
-		InetAddress localAddress = null;
-		try {
-			localAddress = InetAddress.getLocalHost();
-			if (isValidAddress(localAddress)) {
-				return localAddress;
-			}
-		} catch (Throwable e) {
-			logger.error("Failed to retriving ip address, " + e.getMessage(), e);
-		}
 		try {
 			Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
 			if (interfaces != null) {
@@ -78,9 +72,22 @@ public class IpUtil {
 		} catch (Throwable e) {
 			logger.error("Failed to retriving ip address, " + e.getMessage(), e);
 		}
+		
+		
+		InetAddress localAddress = null;
+		try {
+			localAddress = InetAddress.getLocalHost();
+			if (isValidAddress(localAddress)) {
+				return localAddress;
+			}
+		} catch (Throwable e) {
+			logger.error("Failed to retriving ip address, " + e.getMessage(), e);
+		}
+		
 		logger.error("Could not get local host ip address, will use 127.0.0.1 instead.");
 		return localAddress;
 	}
+	
 
 	/**
 	 * get address


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ -] Bugfix


**The description of the PR:**
上线后发现管理中心注册的地址是 87.XXX.XX.XX,这个地址不是线上机器的地址，且ping不通。查看IpUtil.java源码发现优先使用InetAddress.getLocalHost()，对比了rocketmq源码中RemotingUtil.java和其他框架获取本地ip方式都是先遍历网卡找第一个可用的ip,找不到才InetAddress.getLocalHost()。InetAddress.getLocalHost()原理是从hosts中获取ip，hosts或域名服务器异常时获取的就是错误地址。故做此修改。

**Other information:**
InetAddress.getLocalHost()在复杂网络下是不可信的，尤其是hosts信息不正确时候。所以优先遍历网卡来获取第一个可用的外网地址。