### PR TITLE
Docker: add Dockerfile for the xxl-job-executor-samples-springboot

### DIFF
--- a/xxl-job-executor-samples/xxl-job-executor-sample-springboot/.dockerignore
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-springboot/.dockerignore
@@ -1,0 +1,6 @@
+.gitignore
+.git/
+src/
+target/
+target/*.jar.original
+!target/*.jar

--- a/xxl-job-executor-samples/xxl-job-executor-sample-springboot/Dockerfile
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-springboot/Dockerfile
@@ -1,0 +1,23 @@
+FROM openjdk:8-jre
+
+LABEL name="caryyu/xxl-job-executor-sample-springboot" \
+			maintainer="Caryyu <343194291@qq.com>" \
+			version="0.1" \
+			description="A common xxl-job executor image for easily shipping via Docker"
+
+ENV jarName=xxl-job-executor-sample-springboot-2.0.1.jar
+
+ENV TZ=Asia/Shanghai
+RUN ln -snf /usr/share/zoneinfo/TZ /etc/localtime && echo TZ /etc/localtime && echo TZ > /etc/timezone
+
+ADD ./target/$jarName /
+
+ADD ./docker-entrypoint.sh /
+
+RUN chmod u+x /docker-entrypoint.sh
+
+WORKDIR /
+
+EXPOSE 8080
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/xxl-job-executor-samples/xxl-job-executor-sample-springboot/docker-entrypoint.sh
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-springboot/docker-entrypoint.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+java ${JAVA_OPTS} -jar ${jarName} $@


### PR DESCRIPTION
add Dockerfile for the `xxl-job-executor-samples-springboot` as a common executor

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [X] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**
由于 `XXL-JOB` 只提供了调度中心的 `Docker` 镜像，而在部署执行器的时候还是需要利用传统的方式进行处理，为了使用起来方便故封装了一个通用的执行器（基于 `xxl-job-executor-sample-springboot`) 的示例进行封装，因为对应大多数的 Case 而言最常用的就是 `curl` 来做定时接口调用就可以了。

**Other information:**
# docker run
```
docker run --link xxl-job-admin:admin caryyu/xxl-job-executor-sample-springboot --xxl.job.admin.addresses=http://admin:8080/xxl-job-admin
```
> 注意：确保调度中心的容器已经启动 `xxl-job-admin`，可以参考官方文档启动调度中心：http://www.xuxueli.com/xxl-job

# docker compose
```
version: '2.1'
services:
  admin:
    image: xuxueli/xxl-job-admin:2.0.1
    ports:
      - "8080:8080"
    environment:
      PARAMS: |
        --spring.datasource.url=jdbc:mysql://localhost:3306/xxl-job?Unicode=true&characterEncoding=UTF-8
        --spring.datasource.username=root
        --spring.datasource.password=root
        --xxl.job.login.username=admin
        --xxl.job.login.password=admin

  executor:
    image: caryyu/xxl-job-executor-sample-springboot
    links:
      - admin:admin
    depends_on:
      - admin
    command: |
      --xxl.job.admin.addresses=http://admin:8080/xxl-job-admin
```
> 注意：请确保数据库已经存在，可以到官方仓库获取数据库结构语句先手动在数据库进行执行，完毕之后再启动 `docker-compose up` 

# 建议
希望调度中心后期可以支持数据库自检与自建功能，这样就可以不需要每次搭建的时候都要手动执行数据脚本建表。