### PR TITLE
添加数据（伪）流式处理处理支持；修改【任务管理】列表界面的按钮样式

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 target/
 .DS_Store
 .gitattributes
+*.settings

--- a/xxl-job-admin/src/main/resources/static/js/jobinfo.index.1.js
+++ b/xxl-job-admin/src/main/resources/static/js/jobinfo.index.1.js
@@ -126,19 +126,28 @@ $(function() {
 	                			var codeBtn = "";
                                 if ('BEAN' != row.glueType) {
 									var codeUrl = base_url +'/jobcode?jobId='+ row.id;
-									codeBtn = '<a href="'+ codeUrl +'" target="_blank" > <button class="btn btn-warning btn-xs" type="button" >GLUE</button> </a> '
+									codeBtn = '<input type="hidden" class="code-url" value="' + codeUrl + '"/>'
+										    + '<button class="btn btn-warning btn-xs to-code-edit-page" type="button" >GLUE</button>'
 								}
 
 								// html
                                 tableData['key'+row.id] = row;
-								var html = '<p id="'+ row.id +'" >'+
-									'<button class="btn btn-primary btn-xs job_trigger" type="button">'+ I18n.jobinfo_opt_run +'</button>  '+
-                                    start_stop +
-									'<a href="'+ logUrl +'"> <button class="btn btn-primary btn-xs" type="job_del" type="button" >'+ I18n.jobinfo_opt_log +'</button> </a> <br>  '+
-									'<button class="btn btn-warning btn-xs update" type="button">'+ I18n.system_opt_edit +'</button>  '+
-									codeBtn +
-									'<button class="btn btn-danger btn-xs job_operate" _type="job_del" type="button">'+ I18n.system_opt_del +'</button>  '+
-									'</p>';
+								var html = ''
+									+ '<div class="btn-group">' 
+									+ '<button class="btn btn-primary btn-xs job_trigger" type="button">'+ I18n.jobinfo_opt_run +'</button>  '
+									+ '<input type="hidden" class="row-id" value="' + row.id + '"/>'
+									+ start_stop 
+									+ '<input type="hidden" class="log-url" value="' + logUrl + '"/>'
+									+ '<button class="btn btn-primary btn-xs to-log-page" type="job_del" type="button" >'+ I18n.jobinfo_opt_log +'</button>'
+									+ '</div> '
+									
+									+ '<div class="btn-group">'
+									+ '<button class="btn btn-warning btn-xs update" type="button">'+ I18n.system_opt_edit +'</button>  '
+									+ '<input type="hidden" class="row-id" value="' + row.id + '"/>'
+									+ codeBtn 
+									+ '<button class="btn btn-danger btn-xs job_operate" _type="job_del" type="button">'+ I18n.system_opt_del +'</button>  '
+									+ '</div>'
+									+ '';
 
 	                			return html;
 							};
@@ -208,8 +217,7 @@ $(function() {
 		} else {
 			return;
 		}
-		
-		var id = $(this).parent('p').attr("id");
+		var id = $(this).siblings('.row-id').val();
 
 		layer.confirm( I18n.system_ok + typeName + '?', {
 			icon: 3,
@@ -255,7 +263,7 @@ $(function() {
 
     // job trigger
     $("#job_list").on('click', '.job_trigger',function() {
-        var id = $(this).parent('p').attr("id");
+        var id = $(this).siblings('.row-id').val();
         var row = tableData['key'+id];
 
         $("#jobTriggerModal .form input[name='id']").val( row.id );
@@ -434,10 +442,8 @@ $(function() {
 
 	// update
 	$("#job_list").on('click', '.update',function() {
-
-        var id = $(this).parent('p').attr("id");
+        var id = $(this).siblings('.row-id').val();
         var row = tableData['key'+id];
-
 		// base data
 		$("#updateModal .form input[name='id']").val( row.id );
 		$('#updateModal .form select[name=jobGroup] option[value='+ row.jobGroup +']').prop('selected', true);
@@ -459,6 +465,17 @@ $(function() {
 		// show
 		$('#updateModal').modal({backdrop: false, keyboard: false}).modal('show');
 	});
+	
+	$("#job_list").on('click', '.to-log-page', function() {
+		var logUrl = $(this).siblings('.log-url').val();
+		window.open(logUrl)
+	});
+	
+	$("#job_list").on('click', '.to-code-edit-page', function() {
+		var codeUrl = $(this).siblings('.code-url').val();
+		window.open(codeUrl)
+	});
+	
 	var updateModalValidate = $("#updateModal .form").validate({
 		errorElement : 'span',  
         errorClass : 'help-block',

--- a/xxl-job-core/src/main/java/com/xxl/job/core/handler/IDataflowJobHandler.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/handler/IDataflowJobHandler.java
@@ -1,0 +1,81 @@
+package com.xxl.job.core.handler;
+
+import java.util.Collection;
+
+import org.springframework.util.CollectionUtils;
+
+import com.xxl.job.core.biz.model.ReturnT;
+import com.xxl.job.core.log.XxlJobLogger;
+import com.xxl.job.core.util.ShardingUtil;
+import com.xxl.job.core.util.ShardingUtil.ShardingVO;
+
+/**
+ * 数据流处理扩展
+ * @author created by liyong on 2019-1-24 15:30:56
+ */
+public abstract class IDataflowJobHandler<T> extends IJobHandler {
+
+	@Override
+	public ReturnT<String> execute(String param) throws Exception {
+		ShardingUtil.ShardingVO shardingVO = ShardingUtil.getShardingVo();
+		XxlJobLogger.log("分片参数：当前分片序号：{}, 总分片数：{}", shardingVO.getIndex(), shardingVO.getTotal());
+		Collection<T> datas = fetchData(param);
+		int count = 0;
+		do {
+			if (!CollectionUtils.isEmpty(datas)) {
+				int startCount = count;
+				count += datas.size();
+				XxlJobLogger.log("分片参数：当前分片序号：{}, 总分片数：{}, 处理数据：{} - {}", shardingVO.getIndex(), shardingVO.getTotal(), startCount, count);
+				ReturnT<String> result = processData(param, datas);
+				if (result != null && ReturnT.SUCCESS_CODE == result.getCode()) {
+					datas = fetchData(param);
+				} else {
+					return result;
+				}
+				XxlJobLogger.log("分片参数：当前分片序号：{}, 总分片数：{}, 处理数据（SUCCESS）：{} - {}", shardingVO.getIndex(), shardingVO.getTotal(), startCount, count);
+			}
+		} while (!CollectionUtils.isEmpty(datas));
+		return SUCCESS;
+	}
+	
+	private Collection<T> fetchData(String param) {
+		ShardingUtil.ShardingVO shardingVO = ShardingUtil.getShardingVo();
+		Collection<T> datas = null;
+		try {
+			datas = fetchData(shardingVO, param);
+		} catch (Exception e) {
+			XxlJobLogger.log("获取分片数据异常，分片任务已终止，建议人工接入，或开启重试机制，当前分片序号：{}, 总分片数：{}", shardingVO.getIndex(), shardingVO.getTotal());
+			XxlJobLogger.log(e);
+			throw e;
+		}
+		return datas;
+	}
+	
+	private ReturnT<String> processData(String param, Collection<T> data) {
+		ShardingUtil.ShardingVO shardingVO = ShardingUtil.getShardingVo();
+		try {
+			return processData(shardingVO, param, data);
+		} catch (Exception e) {
+			XxlJobLogger.log("分片数据处理失败，分片任务已终止，建议人工接入，或开启重试机制，当前分片序号：{}, 总分片数：{}", shardingVO.getIndex(), shardingVO.getTotal());
+			XxlJobLogger.log(e);
+			throw e;
+		}
+	}
+	
+    /**
+     * 获取待处理数据列表，在具体实现中通过分片信息获取待处理的数据集合，如果返回集合为空，则表示数据已经处理完毕
+     * @param shardingVO 数据分片信息
+     * @param param 任务调度参数
+     * @return 待处理的数据
+     */
+    protected abstract Collection<T> fetchData(ShardingVO shardingVO, String param);
+    
+    /**
+     * 处理数据
+     * @param shardingVO 数据分片信息
+     * @param param 任务调度参数
+     * @param data 待处理的数据
+     */
+    protected abstract ReturnT<String> processData(ShardingVO shardingVO, String param, Collection<T> data);
+	
+}

--- a/xxl-job-executor-samples/xxl-job-executor-sample-springboot/src/main/java/com/xxl/job/executor/service/jobhandler/dataflow/DemoDataflowJobHandler.java
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-springboot/src/main/java/com/xxl/job/executor/service/jobhandler/dataflow/DemoDataflowJobHandler.java
@@ -1,0 +1,38 @@
+package com.xxl.job.executor.service.jobhandler.dataflow;
+
+import java.util.Collection;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.xxl.job.core.biz.model.ReturnT;
+import com.xxl.job.core.handler.IDataflowJobHandler;
+import com.xxl.job.core.handler.annotation.JobHandler;
+import com.xxl.job.core.util.ShardingUtil.ShardingVO;
+import com.xxl.job.executor.service.jobhandler.dataflow.dto.Foo;
+import com.xxl.job.executor.service.jobhandler.dataflow.service.DataService;
+
+/**
+ * 数据流处理Job Demo
+ * @author created by liyong on 2019-1-24 16:01:18
+ */
+@JobHandler(value="demoDataflowJobHandler")
+@Component
+public class DemoDataflowJobHandler extends IDataflowJobHandler<Foo> {
+	@Autowired
+	private DataService dataService;
+	
+	@Override
+	public Collection<Foo> fetchData(ShardingVO shardingVO, String param) {
+		return dataService.getDataPage(1, shardingVO.getIndex(), shardingVO.getTotal());
+	}
+
+	@Override
+	public ReturnT<String> processData(ShardingVO shardingVO, String param, Collection<Foo> data) {
+		for(Foo foo : data) {
+			dataService.update(new Foo(foo.getId(), 1));
+		}
+		return SUCCESS;
+	}
+	
+}

--- a/xxl-job-executor-samples/xxl-job-executor-sample-springboot/src/main/java/com/xxl/job/executor/service/jobhandler/dataflow/dto/Foo.java
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-springboot/src/main/java/com/xxl/job/executor/service/jobhandler/dataflow/dto/Foo.java
@@ -1,0 +1,24 @@
+package com.xxl.job.executor.service.jobhandler.dataflow.dto;
+
+public class Foo {
+	private Integer id;
+	/** 0： 待处理；1：已处理 */
+	private Integer status;
+	public Foo(Integer id, Integer status) {
+		super();
+		this.id = id;
+		this.status = status;
+	}
+	public Integer getId() {
+		return id;
+	}
+	public void setId(Integer id) {
+		this.id = id;
+	}
+	public Integer getStatus() {
+		return status;
+	}
+	public void setStatus(Integer status) {
+		this.status = status;
+	}
+}

--- a/xxl-job-executor-samples/xxl-job-executor-sample-springboot/src/main/java/com/xxl/job/executor/service/jobhandler/dataflow/service/DataService.java
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-springboot/src/main/java/com/xxl/job/executor/service/jobhandler/dataflow/service/DataService.java
@@ -1,0 +1,67 @@
+package com.xxl.job.executor.service.jobhandler.dataflow.service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.stereotype.Service;
+
+import com.xxl.job.executor.service.jobhandler.dataflow.dto.Foo;
+
+@Service
+public class DataService {
+	private static Map<Integer, Foo> dataPool = new HashMap<>();
+	static {
+		dataPool.put(1, new Foo(1, 0));
+		dataPool.put(2, new Foo(2, 0));
+		dataPool.put(3, new Foo(3, 0));
+		dataPool.put(4, new Foo(4, 0));
+		dataPool.put(5, new Foo(5, 0));
+		dataPool.put(6, new Foo(6, 0));
+		dataPool.put(7, new Foo(7, 0));
+		dataPool.put(8, new Foo(8, 0));
+		dataPool.put(9, new Foo(9, 0));
+		dataPool.put(10, new Foo(10, 0));
+		dataPool.put(11, new Foo(11, 0));
+		dataPool.put(12, new Foo(12, 0));
+		dataPool.put(13, new Foo(13, 0));
+		dataPool.put(14, new Foo(14, 0));
+		dataPool.put(15, new Foo(15, 0));
+		dataPool.put(16, new Foo(16, 0));
+	}
+
+	public List<Foo> getDataPage(int page, int shardIndex, int shardTotal) {
+		Set<Integer> keySet = dataPool.keySet();
+		Iterator<Integer> it = keySet.iterator();
+		List<Foo> list = new ArrayList<>();
+		// 模拟查询分片未处理的数据
+		while (it.hasNext()) {
+			Integer id = it.next();
+			if (id % shardTotal == shardIndex && dataPool.get(id).getStatus() == 0) {
+				list.add(dataPool.get(id));
+			}
+		}
+		// 对数据进行分页
+		int pageSize = 3;
+		int startNo = (page - 1) * pageSize;
+		int endNo = page * pageSize;
+		List<Foo> result = new ArrayList<>();
+		if (startNo > list.size()) {
+			return result;
+		}
+		if (endNo > list.size()) {
+			endNo = list.size();
+		}
+		for (int i = startNo; i < endNo; i++) {
+			result.add(new Foo(list.get(i).getId(), list.get(i).getStatus()));
+		}
+		return result;
+	}
+	
+	public void update(Foo foo) {
+		dataPool.get(foo.getId()).setStatus(foo.getStatus());
+	}
+}


### PR DESCRIPTION
添加数据（伪）流式处理处理支持

对com.xxl.job.core.handler.IJobHandler抽象类再次抽象，增加了com.xxl.job.core.handler.IDataflowJobHandler<T>类，该类主要是对大量数据处理进行流式抽象。

并在xxl-job-executor-sample-springboot项目中提供了一个流式处理的代码示例

####################################################

修改【任务管理】列表界面的按钮样式  …
因为按钮分两排，将任务管理界面的表格撑变形。
改动点：
1、将按钮采用分组显示，分为两组；
2、并且将【日志】按钮【GLUE】采用a标签弹出空白页签的方式修改成通过js事件弹出页签（用于适配按钮分组的样式），将a标签中携带的URL地址改成隐藏表单存值，在两个按钮的点击事件时，通过隐藏表单获取URL的值；
3、将每一行的数据ID从原来的p标签记录数据改成通过隐藏表单存数据，将获取p标签中的ID值改成从隐藏表单中获取数据
@xuxueli 