### PR TITLE
优雅停机时，admin快速注销执行器地址

### DIFF
--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobGroupDao.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobGroupDao.java
@@ -16,6 +16,10 @@ public interface XxlJobGroupDao {
 
     public List<XxlJobGroup> findByAddressType(@Param("addressType") int addressType);
 
+    public List<XxlJobGroup> findAutoRegisterGroupByAppName(@Param("appName") String appName);
+
+    public int updateAddressListById(@Param("id") int id, @Param("addressList") String addressList);
+
     public int save(XxlJobGroup xxlJobGroup);
 
     public int update(XxlJobGroup xxlJobGroup);

--- a/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobGroupMapper.xml
+++ b/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobGroupMapper.xml
@@ -27,6 +27,13 @@
 		ORDER BY t.order ASC
 	</select>
 
+	<select id="findAutoRegisterGroupByAppName" resultMap="XxlJobGroup">
+		SELECT <include refid="Base_Column_List" />
+		FROM xxl_job_group AS t
+		WHERE `app_name` = #{appName}
+		AND `address_type` = 0
+	</select>
+
 	<select id="findByAddressType" parameterType="java.lang.Integer" resultMap="XxlJobGroup">
 		SELECT <include refid="Base_Column_List" />
 		FROM xxl_job_group AS t
@@ -46,6 +53,12 @@
 			`order` = #{order},
 			`address_type` = #{addressType},
 			`address_list` = #{addressList}
+		WHERE id = #{id}
+	</update>
+
+	<update id="updateAddressListById">
+		UPDATE xxl_job_group
+		SET `address_list` = #{addressList}
 		WHERE id = #{id}
 	</update>
 

--- a/xxl-job-core/src/main/java/com/xxl/job/core/executor/XxlJobExecutor.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/executor/XxlJobExecutor.java
@@ -86,6 +86,9 @@ public class XxlJobExecutor  {
         initRpcProvider(ip, port, appName, accessToken);
     }
     public void destroy(){
+        // destory executor-server
+        stopRpcProvider();
+
         // destory jobThreadRepository
         if (jobThreadRepository.size() > 0) {
             for (Map.Entry<Integer, JobThread> item: jobThreadRepository.entrySet()) {
@@ -101,9 +104,6 @@ public class XxlJobExecutor  {
 
         // destory TriggerCallbackThread
         TriggerCallbackThread.getInstance().toStop();
-
-        // destory executor-server
-        stopRpcProvider();
 
         // destory invoker
         stopInvokerFactory();


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**
现象：
1.如果RegisterGroup缓存了已停机的服务，会导致调用已停机的机器，快速失败，实际调用效果与使用者预期不符
2.如果配置了重试次数，也有可能在重试时快速失败，直接消耗完重试次数，导致实际重试效果与使用者预期不符
3.client优雅停机时，应该先关闭RpcProvider，否则可能有新任务调度到正在停机的机器，导致快速失败，甚至在CallBack线程销毁后，新进入的任务状态一直停留在执行中

改动：
1.优雅停机时，admin快速注销执行器地址，提高调度机制的可靠性
2.优雅停机时，先执行stopRpcProvider()，防止在停机过程中有新任务进入

fix #1106 

**Other information:**