### PR TITLE
修复powershell脚本在centos环境下执行失败问题

### DIFF
--- a/xxl-job-core/src/main/java/com/xxl/job/core/glue/GlueTypeEnum.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/glue/GlueTypeEnum.java
@@ -11,7 +11,7 @@ public enum GlueTypeEnum {
     GLUE_PYTHON("GLUE(Python)", true, "python", ".py"),
     GLUE_PHP("GLUE(PHP)", true, "php", ".php"),
     GLUE_NODEJS("GLUE(Nodejs)", true, "node", ".js"),
-    GLUE_POWERSHELL("GLUE(PowerShell)", true, "powershell ", ".ps1");
+    GLUE_POWERSHELL("GLUE(PowerShell)", true, "powershell", ".ps1");
 
     private String desc;
     private boolean isScript;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [√] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**
powershell后面有空格，导致在centos powershell core环境执行失败。

**Other information:**