### PR TITLE
任务执行失败告警支持多种提醒方式

### DIFF
--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/alarm/AlarmFactory.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/alarm/AlarmFactory.java
@@ -1,0 +1,39 @@
+package com.xxl.job.admin.core.alarm;
+
+import com.xxl.job.admin.core.util.ClassUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author greenman0007
+ * @time 2019/10/14 14:59
+ */
+public class AlarmFactory {
+    private static Logger logger = LoggerFactory.getLogger(AlarmFactory.class);
+
+    private static Map<AlarmWay, IAlarm> alarmMap = new ConcurrentHashMap();
+
+    public static void creatAlarms() {
+        try {
+            List<Class<?>> classes = ClassUtil.getAllAssignedClass(IAlarm.class);
+            for (Class clz : classes) {
+                IAlarm alarm = (IAlarm) clz.newInstance();
+                alarmMap.put(alarm.getAlarmWay(), alarm);
+            }
+        } catch (Exception e) {
+            logger.error("初始化告警方式出错：", e);
+        }
+    }
+
+    public static IAlarm getAlarm(AlarmWay way) {
+        return alarmMap.get(way);
+    }
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/alarm/AlarmWay.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/alarm/AlarmWay.java
@@ -1,0 +1,25 @@
+package com.xxl.job.admin.core.alarm;
+
+/**
+ * @author greenman0007
+ * @time 2019/10/14 14:25
+ */
+public enum AlarmWay {
+
+    /**
+     * 邮件告警
+     */
+    EMAIL,
+    /**
+     * 短信
+     */
+    SMS,
+    /**
+     * 钉钉
+     */
+    DINGDING,
+    /**
+     * 微信
+     */
+    WEIXIN
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/alarm/DingDingAlarm.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/alarm/DingDingAlarm.java
@@ -1,0 +1,21 @@
+package com.xxl.job.admin.core.alarm;
+
+import com.xxl.job.admin.core.model.XxlJobInfo;
+import com.xxl.job.admin.core.model.XxlJobLog;
+
+/**
+ * @author greenman0007
+ * @time 2019/10/14 14:55
+ */
+public class DingDingAlarm implements IAlarm {
+
+    @Override
+    public AlarmWay getAlarmWay() {
+        return AlarmWay.DINGDING;
+    }
+
+    @Override
+    public boolean failAlarm(XxlJobInfo info, XxlJobLog jobLog) {
+        return false;
+    }
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/alarm/EmailAlarm.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/alarm/EmailAlarm.java
@@ -1,0 +1,102 @@
+package com.xxl.job.admin.core.alarm;
+
+import com.xxl.job.admin.core.conf.XxlJobAdminConfig;
+import com.xxl.job.admin.core.model.XxlJobGroup;
+import com.xxl.job.admin.core.model.XxlJobInfo;
+import com.xxl.job.admin.core.model.XxlJobLog;
+import com.xxl.job.admin.core.util.I18nUtil;
+import com.xxl.job.core.biz.model.ReturnT;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.mail.javamail.MimeMessageHelper;
+
+import javax.mail.internet.MimeMessage;
+import java.text.MessageFormat;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author greenman0007
+ * @time 2019/10/14 14:55
+ */
+public class EmailAlarm implements IAlarm {
+    private static Logger logger = LoggerFactory.getLogger(EmailAlarm.class);
+
+    // email alarm template
+    private static final String mailBodyTemplate = "<h5>" + I18nUtil.getString("jobconf_monitor_detail") + "：</span>" +
+            "<table border=\"1\" cellpadding=\"3\" style=\"border-collapse:collapse; width:80%;\" >\n" +
+            "   <thead style=\"font-weight: bold;color: #ffffff;background-color: #ff8c00;\" >" +
+            "      <tr>\n" +
+            "         <td width=\"20%\" >"+ I18nUtil.getString("jobinfo_field_jobgroup") +"</td>\n" +
+            "         <td width=\"10%\" >"+ I18nUtil.getString("jobinfo_field_id") +"</td>\n" +
+            "         <td width=\"20%\" >"+ I18nUtil.getString("jobinfo_field_jobdesc") +"</td>\n" +
+            "         <td width=\"10%\" >"+ I18nUtil.getString("jobconf_monitor_alarm_title") +"</td>\n" +
+            "         <td width=\"40%\" >"+ I18nUtil.getString("jobconf_monitor_alarm_content") +"</td>\n" +
+            "      </tr>\n" +
+            "   </thead>\n" +
+            "   <tbody>\n" +
+            "      <tr>\n" +
+            "         <td>{0}</td>\n" +
+            "         <td>{1}</td>\n" +
+            "         <td>{2}</td>\n" +
+            "         <td>"+ I18nUtil.getString("jobconf_monitor_alarm_type") +"</td>\n" +
+            "         <td>{3}</td>\n" +
+            "      </tr>\n" +
+            "   </tbody>\n" +
+            "</table>";
+
+    @Override
+    public AlarmWay getAlarmWay() {
+        return AlarmWay.EMAIL;
+    }
+
+    @Override
+    public boolean failAlarm(XxlJobInfo info, XxlJobLog jobLog) {
+        boolean alarmResult = true;
+
+        // send monitor email
+        // alarmContent
+        String alarmContent = "Alarm Job LogId=" + jobLog.getId();
+        if (jobLog.getTriggerCode() != ReturnT.SUCCESS_CODE) {
+            alarmContent += "<br>TriggerMsg=<br>" + jobLog.getTriggerMsg();
+        }
+        if (jobLog.getHandleCode()>0 && jobLog.getHandleCode() != ReturnT.SUCCESS_CODE) {
+            alarmContent += "<br>HandleCode=" + jobLog.getHandleMsg();
+        }
+
+        // email info
+        XxlJobGroup group = XxlJobAdminConfig.getAdminConfig().getXxlJobGroupDao().load(Integer.valueOf(info.getJobGroup()));
+        String personal = I18nUtil.getString("admin_name_full");
+        String title = I18nUtil.getString("jobconf_monitor");
+        String content = MessageFormat.format(mailBodyTemplate,
+                group!=null?group.getTitle():"null",
+                info.getId(),
+                info.getJobDesc(),
+                alarmContent);
+
+        Set<String> emailSet = new HashSet<String>(Arrays.asList(info.getAlarmEmail().split(",")));
+        for (String email: emailSet) {
+
+            // make mail
+            try {
+                MimeMessage mimeMessage = XxlJobAdminConfig.getAdminConfig().getMailSender().createMimeMessage();
+
+                MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true);
+                helper.setFrom(XxlJobAdminConfig.getAdminConfig().getEmailUserName(), personal);
+                helper.setTo(email);
+                helper.setSubject(title);
+                helper.setText(content, true);
+
+                XxlJobAdminConfig.getAdminConfig().getMailSender().send(mimeMessage);
+            } catch (Exception e) {
+                logger.error(">>>>>>>>>>> xxl-job, job fail alarm email send error, JobLogId:{}", jobLog.getId(), e);
+
+                alarmResult = false;
+            }
+
+        }
+
+        return alarmResult;
+    }
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/alarm/IAlarm.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/alarm/IAlarm.java
@@ -1,0 +1,25 @@
+package com.xxl.job.admin.core.alarm;
+
+import com.xxl.job.admin.core.model.XxlJobInfo;
+import com.xxl.job.admin.core.model.XxlJobLog;
+
+/**
+ * @author greenman0007
+ * @time 2019/10/14 14:20
+ */
+public interface IAlarm {
+    /**
+     * 告警方式
+     * @see com.xxl.job.admin.core.alarm.AlarmWay
+     * @return
+     */
+    AlarmWay getAlarmWay();
+
+    /**
+     * 失败告警
+     * @param info
+     * @param jobLog
+     * @return
+     */
+    boolean failAlarm(XxlJobInfo info, XxlJobLog jobLog);
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/alarm/SmsAlarm.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/alarm/SmsAlarm.java
@@ -1,0 +1,21 @@
+package com.xxl.job.admin.core.alarm;
+
+import com.xxl.job.admin.core.model.XxlJobInfo;
+import com.xxl.job.admin.core.model.XxlJobLog;
+
+/**
+ * @author greenman0007
+ * @time 2019/10/14 14:48
+ */
+public class SmsAlarm implements IAlarm {
+
+    @Override
+    public AlarmWay getAlarmWay() {
+        return AlarmWay.SMS;
+    }
+
+    @Override
+    public boolean failAlarm(XxlJobInfo info, XxlJobLog jobLog) {
+        return false;
+    }
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobInfo.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobInfo.java
@@ -20,6 +20,8 @@ public class XxlJobInfo {
 	
 	private String author;		// 负责人
 	private String alarmEmail;	// 报警邮件
+	private String alarmPhone;	// 报警短信手机号
+	private String alarmDingRobot;	// 报警钉钉机器人
 
 	private String executorRouteStrategy;	// 执行器路由策略
 	private String executorHandler;		    // 执行器，任务Handler名称
@@ -214,5 +216,21 @@ public class XxlJobInfo {
 
 	public void setTriggerNextTime(long triggerNextTime) {
 		this.triggerNextTime = triggerNextTime;
+	}
+
+	public String getAlarmPhone() {
+		return alarmPhone;
+	}
+
+	public void setAlarmPhone(String alarmPhone) {
+		this.alarmPhone = alarmPhone;
+	}
+
+	public String getAlarmDingRobot() {
+		return alarmDingRobot;
+	}
+
+	public void setAlarmDingRobot(String alarmDingRobot) {
+		this.alarmDingRobot = alarmDingRobot;
 	}
 }

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobLog.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobLog.java
@@ -32,7 +32,9 @@ public class XxlJobLog {
 	private String handleMsg;
 
 	// alarm info
-	private int alarmStatus;
+	private int emailAlarmStatus;
+	private int smsAlarmStatus;
+	private int dingRobotAlarmStatus;
 
 	public long getId() {
 		return id;
@@ -146,12 +148,27 @@ public class XxlJobLog {
 		this.handleMsg = handleMsg;
 	}
 
-	public int getAlarmStatus() {
-		return alarmStatus;
+	public int getEmailAlarmStatus() {
+		return emailAlarmStatus;
 	}
 
-	public void setAlarmStatus(int alarmStatus) {
-		this.alarmStatus = alarmStatus;
+	public void setEmailAlarmStatus(int emailAlarmStatus) {
+		this.emailAlarmStatus = emailAlarmStatus;
 	}
 
+	public int getSmsAlarmStatus() {
+		return smsAlarmStatus;
+	}
+
+	public void setSmsAlarmStatus(int smsAlarmStatus) {
+		this.smsAlarmStatus = smsAlarmStatus;
+	}
+
+	public int getDingRobotAlarmStatus() {
+		return dingRobotAlarmStatus;
+	}
+
+	public void setDingRobotAlarmStatus(int dingRobotAlarmStatus) {
+		this.dingRobotAlarmStatus = dingRobotAlarmStatus;
+	}
 }

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/util/ClassUtil.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/util/ClassUtil.java
@@ -1,0 +1,48 @@
+package com.xxl.job.admin.core.util;
+
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author greenman0007
+ * @time 2019/10/14 15:35
+ */
+public class ClassUtil {
+
+    public static List<Class<?>> getAllAssignedClass(Class<?> cls) throws ClassNotFoundException {
+        List<Class<?>> classes = new ArrayList<Class<?>>();
+        for (Class<?> c : getClasses(cls)) {
+            if (cls.isAssignableFrom(c) && !cls.equals(c)) {
+                classes.add(c);
+            }
+        }
+        return classes;
+    }
+
+    public static List<Class<?>> getClasses(Class<?> cls) throws ClassNotFoundException {
+        String packageName = cls.getPackage().getName();
+        String path = packageName.replace('.', '/');
+        ClassLoader classloader = Thread.currentThread().getContextClassLoader();
+        URL url = classloader.getResource(path);
+        return getClasses(new File(url.getFile()), packageName);
+    }
+
+    private static List<Class<?>> getClasses(File dir, String packageName) throws ClassNotFoundException {
+        List<Class<?>> classes = new ArrayList<Class<?>>();
+        if (!dir.exists()) {
+            return classes;
+        }
+        for (File f : dir.listFiles()) {
+            if (f.isDirectory()) {
+                classes.addAll(getClasses(f, packageName + "." + f.getName()));
+            }
+            String name = f.getName();
+            if (name.endsWith(".class")) {
+                classes.add(Class.forName(packageName + "." + name.substring(0, name.length() - 6)));
+            }
+        }
+        return classes;
+    }
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobLogDao.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobLogDao.java
@@ -55,6 +55,8 @@ public interface XxlJobLogDao {
 
 	public int updateAlarmStatus(@Param("logId") long logId,
 								 @Param("oldAlarmStatus") int oldAlarmStatus,
-								 @Param("newAlarmStatus") int newAlarmStatus);
+								 @Param("emailAlarmStatus") int emailAlarmStatus,
+								 @Param("smsAlarmStatus") int smsAlarmStatus,
+								 @Param("dingRobotAlarmStatus") int dingRobotAlarmStatus);
 
 }

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/service/impl/XxlJobServiceImpl.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/service/impl/XxlJobServiceImpl.java
@@ -210,6 +210,8 @@ public class XxlJobServiceImpl implements XxlJobService {
 		exists_jobInfo.setJobDesc(jobInfo.getJobDesc());
 		exists_jobInfo.setAuthor(jobInfo.getAuthor());
 		exists_jobInfo.setAlarmEmail(jobInfo.getAlarmEmail());
+		exists_jobInfo.setAlarmPhone(jobInfo.getAlarmPhone());
+		exists_jobInfo.setAlarmDingRobot(jobInfo.getAlarmDingRobot());
 		exists_jobInfo.setExecutorRouteStrategy(jobInfo.getExecutorRouteStrategy());
 		exists_jobInfo.setExecutorHandler(jobInfo.getExecutorHandler());
 		exists_jobInfo.setExecutorParam(jobInfo.getExecutorParam());

--- a/xxl-job-admin/src/main/resources/i18n/message.properties
+++ b/xxl-job-admin/src/main/resources/i18n/message.properties
@@ -252,3 +252,7 @@ user_update_loginuser_limit=禁止操作当前登录账号
 ## help
 job_help=使用教程
 job_help_document=官方文档
+jobinfo_field_alarmphone=报警短信手机号
+jobinfo_field_alarmdingrobot=报警钉钉机器人地址
+jobinfo_alarmphone_placeholder=请输入报警短信手机号
+jobinfo_field_alarmdingrobot_placeholder=请输入报警钉钉机器人URL

--- a/xxl-job-admin/src/main/resources/i18n/message_en.properties
+++ b/xxl-job-admin/src/main/resources/i18n/message_en.properties
@@ -252,3 +252,7 @@ user_update_loginuser_limit=Operation of current login account is not allowed
 ## help
 job_help=Tutorial
 job_help_document=Official Document
+jobinfo_field_alarmphone=Alarm SMS phone number
+jobinfo_field_alarmdingrobot=Alarm dingding robot url
+jobinfo_alarmphone_placeholder=Please enter alarm SMS phone number.
+jobinfo_field_alarmdingrobot_placeholder=Please enter alarm dingding robot url.

--- a/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobInfoMapper.xml
+++ b/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobInfoMapper.xml
@@ -15,6 +15,8 @@
 
 	    <result column="author" property="author" />
 	    <result column="alarm_email" property="alarmEmail" />
+		<result column="alarm_phone" property="alarmPhone" />
+		<result column="alarm_ding_robot" property="alarmDingRobot" />
 
 		<result column="executor_route_strategy" property="executorRouteStrategy" />
 		<result column="executor_handler" property="executorHandler" />
@@ -44,6 +46,8 @@
 		t.update_time,
 		t.author,
 		t.alarm_email,
+		t.alarm_phone,
+		t.alarm_ding_robot,
 		t.executor_route_strategy,
 		t.executor_handler,
 		t.executor_param,
@@ -115,6 +119,8 @@
 			update_time,
 			author,
 			alarm_email,
+			alarm_phone,
+			alarm_ding_robot,
             executor_route_strategy,
 			executor_handler,
 			executor_param,
@@ -137,6 +143,8 @@
 			NOW(),
 			#{author},
 			#{alarmEmail},
+			#{alarmPhone},
+			#{alarmDingRobot},
 			#{executorRouteStrategy},
 			#{executorHandler},
 			#{executorParam},
@@ -173,6 +181,8 @@
 			update_time = NOW(),
 			author = #{author},
 			alarm_email = #{alarmEmail},
+			alarm_phone = #{alarmPhone},
+			alarm_ding_robot = #{alarmDingRobot},
 			executor_route_strategy = #{executorRouteStrategy},
 			executor_handler = #{executorHandler},
 			executor_param = #{executorParam},

--- a/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobLogMapper.xml
+++ b/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobLogMapper.xml
@@ -23,7 +23,9 @@
 	    <result column="handle_code" property="handleCode" />
 	    <result column="handle_msg" property="handleMsg" />
 
-		<result column="alarm_status" property="alarmStatus" />
+		<result column="email_alarm_status" property="emailAlarmStatus" />
+		<result column="sms_alarm_status" property="smsAlarmStatus" />
+		<result column="ding_robot_alarm_status" property="dingRobotAlarmStatus" />
 	</resultMap>
 
 	<sql id="Base_Column_List">
@@ -41,7 +43,9 @@
 		t.handle_time,
 		t.handle_code,
 		t.handle_msg,
-		t.alarm_status
+		t.email_alarm_status,
+		t.sms_alarm_status,
+		t.ding_robot_alarm_status
 	</sql>
 	
 	<select id="pageList" resultMap="XxlJobLog">
@@ -225,7 +229,7 @@
 			OR
 			(handle_code = 200)
 		)
-		AND `alarm_status` = 0
+		AND (`email_alarm_status` = 0 or `sms_alarm_status` = 0 or `ding_robot_alarm_status` = 0)
 		ORDER BY id ASC
 	</select>
 
@@ -235,7 +239,7 @@
 			`email_alarm_status` = #{emailAlarmStatus},
 			`sms_alarm_status` = #{smsAlarmStatus},
 			`ding_robot_alarm_status` = #{dingRobotAlarmStatus}
-		WHERE `id`= #{logId} AND `alarm_status` = #{oldAlarmStatus}
+		WHERE `id`= #{logId} AND (`email_alarm_status` = #{oldAlarmStatus} or `sms_alarm_status` = #{oldAlarmStatus} or `ding_robot_alarm_status` = #{oldAlarmStatus})
 	</update>
 	
 </mapper>

--- a/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobLogMapper.xml
+++ b/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobLogMapper.xml
@@ -232,7 +232,9 @@
 	<update id="updateAlarmStatus" >
 		UPDATE xxl_job_log
 		SET
-			`alarm_status` = #{newAlarmStatus}
+			`email_alarm_status` = #{emailAlarmStatus},
+			`sms_alarm_status` = #{smsAlarmStatus},
+			`ding_robot_alarm_status` = #{dingRobotAlarmStatus}
 		WHERE `id`= #{logId} AND `alarm_status` = #{oldAlarmStatus}
 	</update>
 	

--- a/xxl-job-admin/src/main/resources/static/js/jobinfo.index.1.js
+++ b/xxl-job-admin/src/main/resources/static/js/jobinfo.index.1.js
@@ -467,6 +467,8 @@ $(function() {
 		$("#updateModal .form input[name='jobCron']").val( row.jobCron );
 		$("#updateModal .form input[name='author']").val( row.author );
 		$("#updateModal .form input[name='alarmEmail']").val( row.alarmEmail );
+		$("#updateModal .form input[name='alarmPhone']").val( row.alarmPhone );
+		$("#updateModal .form input[name='alarmDingRobot']").val( row.alarmDingRobot );
 		$("#updateModal .form input[name='executorTimeout']").val( row.executorTimeout );
         $("#updateModal .form input[name='executorFailRetryCount']").val( row.executorFailRetryCount );
 		$('#updateModal .form select[name=executorRouteStrategy] option[value='+ row.executorRouteStrategy +']').prop('selected', true);

--- a/xxl-job-admin/src/main/resources/templates/jobinfo/jobinfo.index.ftl
+++ b/xxl-job-admin/src/main/resources/templates/jobinfo/jobinfo.index.ftl
@@ -371,6 +371,14 @@ exit 0
                         <div class="col-sm-4"><input type="text" class="form-control" name="alarmEmail" placeholder="${I18n.jobinfo_field_alarmemail_placeholder}" maxlength="100" ></div>
                     </div>
                     <div class="form-group">
+                        <label for="lastname" class="col-sm-2 control-label">${I18n.jobinfo_field_alarmphone}<font color="red">*</font></label>
+                        <div class="col-sm-4"><input type="text" class="form-control" name="alarmPhone" placeholder="${I18n.system_please_input}${I18n.jobinfo_alarmphone_placeholder}" maxlength="50" ></div>
+                    </div>
+                    <div class="form-group">
+                        <label for="lastname" class="col-sm-2 control-label">${I18n.jobinfo_field_alarmdingrobot}<font color="black">*</font></label>
+                        <div class="col-sm-10"><input type="text" class="form-control" name="alarmDingRobot" placeholder="${I18n.jobinfo_field_alarmdingrobot_placeholder}" maxlength="200" ></div>
+                    </div>
+                    <div class="form-group">
                         <label for="firstname" class="col-sm-2 control-label">${I18n.jobinfo_field_executorparam}<font color="black">*</font></label>
                         <div class="col-sm-10">
                             <textarea class="textarea form-control" name="executorParam" placeholder="${I18n.system_please_input}${I18n.jobinfo_field_executorparam}" maxlength="512" style="height: 63px; line-height: 1.2;"></textarea>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**

增加告警接口，开发者可自定义实现不同的告警方式。目前支持email，SMS，钉钉。

**Other information:**
DML：
ALTER TABLE `xxl_job`.`xxl_job_info` 
ADD COLUMN `alarm_phone` varchar(255) NULL COMMENT '报警短信手机号' AFTER `alarm_email`,
ADD COLUMN `alarm_ding_robot` varchar(255) NULL COMMENT '报警钉钉机器人' AFTER `alarm_phone`;

ALTER TABLE `xxl_job`.`xxl_job_log` 
CHANGE COLUMN `alarm_status` `email_alarm_status` tinyint(4) NOT NULL DEFAULT 0 COMMENT '邮件告警状态：0-默认、1-无需告警、2-告警成功、3-告警失败' AFTER `handle_msg`,
ADD COLUMN `sms_alarm_status` tinyint(4) NOT NULL DEFAULT 0 COMMENT '短信告警状态：0-默认、1-无需告警、2-告警成功、3-告警失败' AFTER `email_alarm_status`,
ADD COLUMN `ding_robot_alarm_status` tinyint(4) NOT NULL DEFAULT 0 COMMENT '钉钉机器人告警状态：0-默认、1-无需告警、2-告警成功、3-告警失败' AFTER `sms_alarm_status`;