### PR TITLE
优化在JobThread尝试30次后销毁任务时，并发插入到triggerQueue中任务会失败的场景

### DIFF
--- a/xxl-job-core/src/main/java/com/xxl/job/core/thread/JobThread.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/thread/JobThread.java
@@ -165,7 +165,9 @@ public class JobThread extends Thread{
 
 				} else {
 					if (idleTimes > 30) {
-						XxlJobExecutor.removeJobThread(jobId, "excutor idel times over limit.");
+						if(triggerQueue ==null||triggerQueue.size()==0) {
+							XxlJobExecutor.removeJobThread(jobId, "excutor idel times over limit.");
+						}
 					}
 				}
 			} catch (Throwable e) {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**
优化在JobThread尝试30次后销毁任务时，并发插入到triggerQueue中任务会失败的场景
例如：
任务A的执行间隔是98秒，执行任务耗时为5秒。
第一次触发执行后，JobThread需要在经过5+31*3=98秒销毁JobThread。
```
if (idleTimes > 30) {    
      XxlJobExecutor.removeJobThread(jobId, "excutor idel times over limit.");   
}
```
那么在调用removeJobThread之前，刚好触发了第二次任务，插入到了triggerQueue中。后面会销毁任务，并且把triggerQueue中任务都设定为失败。
这里是否可以优化下在销毁前在判断triggerQueue中是否存在数据，如果没有继续销毁，如果有则继续while循环执行任务。可以避免一定程度的任务失败？
**Other information:**