### PR TITLE
Using non-final variables to lock can cause thread-safety problems.Ac…

### DIFF
--- a/xxl-job-core/src/main/java/com/xxl/job/core/util/DateUtil.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/util/DateUtil.java
@@ -24,7 +24,7 @@ public class DateUtil {
     private static final String DATE_FORMAT = "yyyy-MM-dd";
     private static final String DATETIME_FORMAT = "yyyy-MM-dd HH:mm:ss";
 
-    private static ThreadLocal<Map<String, DateFormat>> dateFormatThreadLocal = new ThreadLocal<Map<String, DateFormat>>();
+    private static final ThreadLocal<Map<String, DateFormat>> dateFormatThreadLocal = new ThreadLocal<Map<String, DateFormat>>();
     private static DateFormat getDateFormat(String pattern) {
         if (pattern==null || pattern.trim().length()==0) {
             throw new IllegalArgumentException("pattern cannot be empty.");


### PR DESCRIPTION
…cording to my understanding, it is appropriate to add the final keyword here

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**
Using non-final variables to lock can cause thread-safety problems.According to my understanding, it is appropriate to add the final keyword here

**Other information:**