### PR TITLE
重构并增强HttpJobHandler对Restful的其他HTTP method的支持

### DIFF
--- a/xxl-job-executor-samples/xxl-job-executor-sample-frameless/src/main/java/com/xuxueli/executor/sample/frameless/jobhandler/HttpJobHandler.java
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-frameless/src/main/java/com/xuxueli/executor/sample/frameless/jobhandler/HttpJobHandler.java
@@ -8,6 +8,7 @@ import com.xxl.job.core.log.XxlJobLogger;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
@@ -46,6 +47,12 @@ public class HttpJobHandler extends IJobHandler {
 			connection.setRequestProperty("connection", "Keep-Alive");
 			connection.setRequestProperty("Content-Type", "application/json;charset=UTF-8");
 			connection.setRequestProperty("Accept-Charset", "application/json;charset=UTF-8");
+
+			if (httpRequestParam.getRequestBody() != null) {
+				OutputStream outputStream = connection.getOutputStream();
+				byte[] requestBody = httpRequestParam.getRequestBody().getBytes("UTF-8");
+				outputStream.write(requestBody, 0 , requestBody.length);
+			}
 
 			// do connection
 			connection.connect();

--- a/xxl-job-executor-samples/xxl-job-executor-sample-frameless/src/main/java/com/xuxueli/executor/sample/frameless/jobhandler/HttpJobHandler.java
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-frameless/src/main/java/com/xuxueli/executor/sample/frameless/jobhandler/HttpJobHandler.java
@@ -1,5 +1,7 @@
 package com.xuxueli.executor.sample.frameless.jobhandler;
 
+import com.xuxueli.executor.sample.frameless.jobhandler.param.HttpRequestParam;
+import com.xuxueli.executor.sample.frameless.jobhandler.param.HttpRequestParamHandler;
 import com.xxl.job.core.biz.model.ReturnT;
 import com.xxl.job.core.handler.IJobHandler;
 import com.xxl.job.core.log.XxlJobLogger;
@@ -30,11 +32,12 @@ public class HttpJobHandler extends IJobHandler {
 		BufferedReader bufferedReader = null;
 		try {
 			// connection
-			URL realUrl = new URL(param);
+			HttpRequestParam httpRequestParam = HttpRequestParamHandler.getInstance().convertParam(param);
+			URL realUrl = new URL(httpRequestParam.getEndpoint());
 			connection = (HttpURLConnection) realUrl.openConnection();
 
 			// connection setting
-			connection.setRequestMethod("GET");
+			connection.setRequestMethod(httpRequestParam.getHttpMethod());
 			connection.setDoOutput(true);
 			connection.setDoInput(true);
 			connection.setUseCaches(false);

--- a/xxl-job-executor-samples/xxl-job-executor-sample-frameless/src/main/java/com/xuxueli/executor/sample/frameless/jobhandler/param/HttpRequestParam.java
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-frameless/src/main/java/com/xuxueli/executor/sample/frameless/jobhandler/param/HttpRequestParam.java
@@ -1,0 +1,32 @@
+package com.xuxueli.executor.sample.frameless.jobhandler.param;
+
+
+public class HttpRequestParam {
+    private String httpMethod;
+    private String endpoint;
+    private String requestBody;
+
+    public String getHttpMethod() {
+        return httpMethod;
+    }
+
+    public void setHttpMethod(String httpMethod) {
+        this.httpMethod = httpMethod;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public String getRequestBody() {
+        return requestBody;
+    }
+
+    public void setRequestBody(String requestBody) {
+        this.requestBody = requestBody;
+    }
+}

--- a/xxl-job-executor-samples/xxl-job-executor-sample-frameless/src/main/java/com/xuxueli/executor/sample/frameless/jobhandler/param/HttpRequestParamHandler.java
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-frameless/src/main/java/com/xuxueli/executor/sample/frameless/jobhandler/param/HttpRequestParamHandler.java
@@ -1,0 +1,56 @@
+package com.xuxueli.executor.sample.frameless.jobhandler.param;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class HttpRequestParamHandler {
+    private static final String HTTP_METHODS = "^(GET|PUT|POST|PATCH|DELETE)";
+    private static final String URL = "(https?://[^\\s]+)";
+    private static final String REQUEST_BODY = "(\\{.*})";
+
+    private static final HttpRequestParamHandler instance = new HttpRequestParamHandler();
+
+    public static HttpRequestParamHandler getInstance() {
+        return instance;
+    }
+
+    public HttpRequestParam convertParam(String param) {
+        HttpRequestParam httpRequestParam = new HttpRequestParam();
+
+        Pattern patternOne = Pattern.compile(HTTP_METHODS + " " + URL + " " + REQUEST_BODY);
+        Pattern patternTwo = Pattern.compile(HTTP_METHODS + " " + URL);
+        Pattern patternThree = Pattern.compile(URL);
+
+        List<Pattern> allowedPatterns = Arrays.asList(patternOne, patternTwo, patternThree);
+
+        Matcher matcher;
+        for (Pattern pattern : allowedPatterns) {
+            matcher = pattern.matcher(param);
+            if (matcher.matches()) {
+                if (matcher.groupCount() == 3) {
+                    httpRequestParam.setHttpMethod(matcher.group(1));
+                    httpRequestParam.setEndpoint(matcher.group(2));
+                    httpRequestParam.setRequestBody(matcher.group(3));
+                }
+                if (matcher.groupCount() == 2) {
+                    httpRequestParam.setHttpMethod(matcher.group(1));
+                    httpRequestParam.setEndpoint(matcher.group(2));
+                }
+                if (matcher.groupCount() == 1) {
+                    httpRequestParam.setHttpMethod("GET");
+                    httpRequestParam.setEndpoint(matcher.group(1));
+                }
+            }
+
+        }
+
+        if (httpRequestParam.getHttpMethod() == null) {
+            throw new RuntimeException("Pattern does not match, please check param format");
+        }
+
+        return httpRequestParam;
+    }
+
+}

--- a/xxl-job-executor-samples/xxl-job-executor-sample-jboot/src/main/java/com/xuxueli/executor/sample/jboot/jobhandler/HttpJobHandler.java
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-jboot/src/main/java/com/xuxueli/executor/sample/jboot/jobhandler/HttpJobHandler.java
@@ -1,5 +1,7 @@
 package com.xuxueli.executor.sample.jboot.jobhandler;
 
+import com.xuxueli.executor.sample.jboot.jobhandler.param.HttpRequestParam;
+import com.xuxueli.executor.sample.jboot.jobhandler.param.HttpRequestParamHandler;
 import com.xxl.job.core.biz.model.ReturnT;
 import com.xxl.job.core.handler.IJobHandler;
 import com.xxl.job.core.log.XxlJobLogger;
@@ -24,11 +26,12 @@ public class HttpJobHandler extends IJobHandler {
         BufferedReader bufferedReader = null;
         try {
             // connection
-            URL realUrl = new URL(param);
+            HttpRequestParam httpRequestParam = HttpRequestParamHandler.getInstance().convertParam(param);
+            URL realUrl = new URL(httpRequestParam.getEndpoint());
             connection = (HttpURLConnection) realUrl.openConnection();
 
             // connection setting
-            connection.setRequestMethod("GET");
+            connection.setRequestMethod(httpRequestParam.getHttpMethod());
             connection.setDoOutput(true);
             connection.setDoInput(true);
             connection.setUseCaches(false);

--- a/xxl-job-executor-samples/xxl-job-executor-sample-jboot/src/main/java/com/xuxueli/executor/sample/jboot/jobhandler/HttpJobHandler.java
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-jboot/src/main/java/com/xuxueli/executor/sample/jboot/jobhandler/HttpJobHandler.java
@@ -8,6 +8,7 @@ import com.xxl.job.core.log.XxlJobLogger;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
@@ -40,6 +41,12 @@ public class HttpJobHandler extends IJobHandler {
             connection.setRequestProperty("connection", "Keep-Alive");
             connection.setRequestProperty("Content-Type", "application/json;charset=UTF-8");
             connection.setRequestProperty("Accept-Charset", "application/json;charset=UTF-8");
+
+            if (httpRequestParam.getRequestBody() != null) {
+                OutputStream outputStream = connection.getOutputStream();
+                byte[] requestBody = httpRequestParam.getRequestBody().getBytes("UTF-8");
+                outputStream.write(requestBody, 0 , requestBody.length);
+            }
 
             // do connection
             connection.connect();

--- a/xxl-job-executor-samples/xxl-job-executor-sample-jboot/src/main/java/com/xuxueli/executor/sample/jboot/jobhandler/param/HttpRequestParam.java
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-jboot/src/main/java/com/xuxueli/executor/sample/jboot/jobhandler/param/HttpRequestParam.java
@@ -1,0 +1,32 @@
+package com.xuxueli.executor.sample.jboot.jobhandler.param;
+
+
+public class HttpRequestParam {
+    private String httpMethod;
+    private String endpoint;
+    private String requestBody;
+
+    public String getHttpMethod() {
+        return httpMethod;
+    }
+
+    public void setHttpMethod(String httpMethod) {
+        this.httpMethod = httpMethod;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public String getRequestBody() {
+        return requestBody;
+    }
+
+    public void setRequestBody(String requestBody) {
+        this.requestBody = requestBody;
+    }
+}

--- a/xxl-job-executor-samples/xxl-job-executor-sample-jboot/src/main/java/com/xuxueli/executor/sample/jboot/jobhandler/param/HttpRequestParamHandler.java
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-jboot/src/main/java/com/xuxueli/executor/sample/jboot/jobhandler/param/HttpRequestParamHandler.java
@@ -1,0 +1,56 @@
+package com.xuxueli.executor.sample.jboot.jobhandler.param;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class HttpRequestParamHandler {
+    private static final String HTTP_METHODS = "^(GET|PUT|POST|PATCH|DELETE)";
+    private static final String URL = "(https?://[^\\s]+)";
+    private static final String REQUEST_BODY = "(\\{.*})";
+
+    private static final HttpRequestParamHandler instance = new HttpRequestParamHandler();
+
+    public static HttpRequestParamHandler getInstance() {
+        return instance;
+    }
+
+    public HttpRequestParam convertParam(String param) {
+        HttpRequestParam httpRequestParam = new HttpRequestParam();
+
+        Pattern patternOne = Pattern.compile(HTTP_METHODS + " " + URL + " " + REQUEST_BODY);
+        Pattern patternTwo = Pattern.compile(HTTP_METHODS + " " + URL);
+        Pattern patternThree = Pattern.compile(URL);
+
+        List<Pattern> allowedPatterns = Arrays.asList(patternOne, patternTwo, patternThree);
+
+        Matcher matcher;
+        for (Pattern pattern : allowedPatterns) {
+            matcher = pattern.matcher(param);
+            if (matcher.matches()) {
+                if (matcher.groupCount() == 3) {
+                    httpRequestParam.setHttpMethod(matcher.group(1));
+                    httpRequestParam.setEndpoint(matcher.group(2));
+                    httpRequestParam.setRequestBody(matcher.group(3));
+                }
+                if (matcher.groupCount() == 2) {
+                    httpRequestParam.setHttpMethod(matcher.group(1));
+                    httpRequestParam.setEndpoint(matcher.group(2));
+                }
+                if (matcher.groupCount() == 1) {
+                    httpRequestParam.setHttpMethod("GET");
+                    httpRequestParam.setEndpoint(matcher.group(1));
+                }
+            }
+
+        }
+
+        if (httpRequestParam.getHttpMethod() == null) {
+            throw new RuntimeException("Pattern does not match, please check param format");
+        }
+
+        return httpRequestParam;
+    }
+
+}

--- a/xxl-job-executor-samples/xxl-job-executor-sample-jfinal/src/main/java/com/xuxueli/executor/sample/jfinal/jobhandler/HttpJobHandler.java
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-jfinal/src/main/java/com/xuxueli/executor/sample/jfinal/jobhandler/HttpJobHandler.java
@@ -8,6 +8,7 @@ import com.xxl.job.core.log.XxlJobLogger;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
@@ -40,6 +41,12 @@ public class HttpJobHandler extends IJobHandler {
             connection.setRequestProperty("connection", "Keep-Alive");
             connection.setRequestProperty("Content-Type", "application/json;charset=UTF-8");
             connection.setRequestProperty("Accept-Charset", "application/json;charset=UTF-8");
+
+            if (httpRequestParam.getRequestBody() != null) {
+                OutputStream outputStream = connection.getOutputStream();
+                byte[] requestBody = httpRequestParam.getRequestBody().getBytes("UTF-8");
+                outputStream.write(requestBody, 0 , requestBody.length);
+            }
 
             // do connection
             connection.connect();

--- a/xxl-job-executor-samples/xxl-job-executor-sample-jfinal/src/main/java/com/xuxueli/executor/sample/jfinal/jobhandler/HttpJobHandler.java
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-jfinal/src/main/java/com/xuxueli/executor/sample/jfinal/jobhandler/HttpJobHandler.java
@@ -1,5 +1,7 @@
 package com.xuxueli.executor.sample.jfinal.jobhandler;
 
+import com.xuxueli.executor.sample.jfinal.jobhandler.param.HttpRequestParam;
+import com.xuxueli.executor.sample.jfinal.jobhandler.param.HttpRequestParamHandler;
 import com.xxl.job.core.biz.model.ReturnT;
 import com.xxl.job.core.handler.IJobHandler;
 import com.xxl.job.core.log.XxlJobLogger;
@@ -24,11 +26,12 @@ public class HttpJobHandler extends IJobHandler {
         BufferedReader bufferedReader = null;
         try {
             // connection
-            URL realUrl = new URL(param);
+            HttpRequestParam httpRequestParam = HttpRequestParamHandler.getInstance().convertParam(param);
+            URL realUrl = new URL(httpRequestParam.getEndpoint());
             connection = (HttpURLConnection) realUrl.openConnection();
 
             // connection setting
-            connection.setRequestMethod("GET");
+            connection.setRequestMethod(httpRequestParam.getHttpMethod());
             connection.setDoOutput(true);
             connection.setDoInput(true);
             connection.setUseCaches(false);

--- a/xxl-job-executor-samples/xxl-job-executor-sample-jfinal/src/main/java/com/xuxueli/executor/sample/jfinal/jobhandler/param/HttpRequestParam.java
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-jfinal/src/main/java/com/xuxueli/executor/sample/jfinal/jobhandler/param/HttpRequestParam.java
@@ -1,0 +1,32 @@
+package com.xuxueli.executor.sample.jfinal.jobhandler.param;
+
+
+public class HttpRequestParam {
+    private String httpMethod;
+    private String endpoint;
+    private String requestBody;
+
+    public String getHttpMethod() {
+        return httpMethod;
+    }
+
+    public void setHttpMethod(String httpMethod) {
+        this.httpMethod = httpMethod;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public String getRequestBody() {
+        return requestBody;
+    }
+
+    public void setRequestBody(String requestBody) {
+        this.requestBody = requestBody;
+    }
+}

--- a/xxl-job-executor-samples/xxl-job-executor-sample-jfinal/src/main/java/com/xuxueli/executor/sample/jfinal/jobhandler/param/HttpRequestParamHandler.java
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-jfinal/src/main/java/com/xuxueli/executor/sample/jfinal/jobhandler/param/HttpRequestParamHandler.java
@@ -1,0 +1,56 @@
+package com.xuxueli.executor.sample.jfinal.jobhandler.param;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class HttpRequestParamHandler {
+    private static final String HTTP_METHODS = "^(GET|PUT|POST|PATCH|DELETE)";
+    private static final String URL = "(https?://[^\\s]+)";
+    private static final String REQUEST_BODY = "(\\{.*})";
+
+    private static final HttpRequestParamHandler instance = new HttpRequestParamHandler();
+
+    public static HttpRequestParamHandler getInstance() {
+        return instance;
+    }
+
+    public HttpRequestParam convertParam(String param) {
+        HttpRequestParam httpRequestParam = new HttpRequestParam();
+
+        Pattern patternOne = Pattern.compile(HTTP_METHODS + " " + URL + " " + REQUEST_BODY);
+        Pattern patternTwo = Pattern.compile(HTTP_METHODS + " " + URL);
+        Pattern patternThree = Pattern.compile(URL);
+
+        List<Pattern> allowedPatterns = Arrays.asList(patternOne, patternTwo, patternThree);
+
+        Matcher matcher;
+        for (Pattern pattern : allowedPatterns) {
+            matcher = pattern.matcher(param);
+            if (matcher.matches()) {
+                if (matcher.groupCount() == 3) {
+                    httpRequestParam.setHttpMethod(matcher.group(1));
+                    httpRequestParam.setEndpoint(matcher.group(2));
+                    httpRequestParam.setRequestBody(matcher.group(3));
+                }
+                if (matcher.groupCount() == 2) {
+                    httpRequestParam.setHttpMethod(matcher.group(1));
+                    httpRequestParam.setEndpoint(matcher.group(2));
+                }
+                if (matcher.groupCount() == 1) {
+                    httpRequestParam.setHttpMethod("GET");
+                    httpRequestParam.setEndpoint(matcher.group(1));
+                }
+            }
+
+        }
+
+        if (httpRequestParam.getHttpMethod() == null) {
+            throw new RuntimeException("Pattern does not match, please check param format");
+        }
+
+        return httpRequestParam;
+    }
+
+}

--- a/xxl-job-executor-samples/xxl-job-executor-sample-nutz/src/main/java/com/xuxueli/executor/sample/nutz/jobhandler/HttpJobHandler.java
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-nutz/src/main/java/com/xuxueli/executor/sample/nutz/jobhandler/HttpJobHandler.java
@@ -10,6 +10,7 @@ import org.nutz.ioc.loader.annotation.IocBean;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
@@ -45,6 +46,12 @@ public class HttpJobHandler extends IJobHandler {
             connection.setRequestProperty("Content-Type", "application/json;charset=UTF-8");
             connection.setRequestProperty("Accept-Charset", "application/json;charset=UTF-8");
 
+            if (httpRequestParam.getRequestBody() != null) {
+                OutputStream outputStream = connection.getOutputStream();
+                byte[] requestBody = httpRequestParam.getRequestBody().getBytes("UTF-8");
+                outputStream.write(requestBody, 0 , requestBody.length);
+            }
+            
             // do connection
             connection.connect();
 

--- a/xxl-job-executor-samples/xxl-job-executor-sample-nutz/src/main/java/com/xuxueli/executor/sample/nutz/jobhandler/HttpJobHandler.java
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-nutz/src/main/java/com/xuxueli/executor/sample/nutz/jobhandler/HttpJobHandler.java
@@ -1,5 +1,7 @@
 package com.xuxueli.executor.sample.nutz.jobhandler;
 
+import com.xuxueli.executor.sample.nutz.jobhandler.param.HttpRequestParam;
+import com.xuxueli.executor.sample.nutz.jobhandler.param.HttpRequestParamHandler;
 import com.xxl.job.core.biz.model.ReturnT;
 import com.xxl.job.core.handler.IJobHandler;
 import com.xxl.job.core.handler.annotation.JobHandler;
@@ -28,11 +30,12 @@ public class HttpJobHandler extends IJobHandler {
         BufferedReader bufferedReader = null;
         try {
             // connection
-            URL realUrl = new URL(param);
+            HttpRequestParam httpRequestParam = HttpRequestParamHandler.getInstance().convertParam(param);
+            URL realUrl = new URL(httpRequestParam.getEndpoint());
             connection = (HttpURLConnection) realUrl.openConnection();
 
             // connection setting
-            connection.setRequestMethod("GET");
+            connection.setRequestMethod(httpRequestParam.getHttpMethod());
             connection.setDoOutput(true);
             connection.setDoInput(true);
             connection.setUseCaches(false);

--- a/xxl-job-executor-samples/xxl-job-executor-sample-nutz/src/main/java/com/xuxueli/executor/sample/nutz/jobhandler/param/HttpRequestParam.java
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-nutz/src/main/java/com/xuxueli/executor/sample/nutz/jobhandler/param/HttpRequestParam.java
@@ -1,0 +1,32 @@
+package com.xuxueli.executor.sample.nutz.jobhandler.param;
+
+
+public class HttpRequestParam {
+    private String httpMethod;
+    private String endpoint;
+    private String requestBody;
+
+    public String getHttpMethod() {
+        return httpMethod;
+    }
+
+    public void setHttpMethod(String httpMethod) {
+        this.httpMethod = httpMethod;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public String getRequestBody() {
+        return requestBody;
+    }
+
+    public void setRequestBody(String requestBody) {
+        this.requestBody = requestBody;
+    }
+}

--- a/xxl-job-executor-samples/xxl-job-executor-sample-nutz/src/main/java/com/xuxueli/executor/sample/nutz/jobhandler/param/HttpRequestParamHandler.java
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-nutz/src/main/java/com/xuxueli/executor/sample/nutz/jobhandler/param/HttpRequestParamHandler.java
@@ -1,0 +1,56 @@
+package com.xuxueli.executor.sample.nutz.jobhandler.param;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class HttpRequestParamHandler {
+    private static final String HTTP_METHODS = "^(GET|PUT|POST|PATCH|DELETE)";
+    private static final String URL = "(https?://[^\\s]+)";
+    private static final String REQUEST_BODY = "(\\{.*})";
+
+    private static final HttpRequestParamHandler instance = new HttpRequestParamHandler();
+
+    public static HttpRequestParamHandler getInstance() {
+        return instance;
+    }
+
+    public HttpRequestParam convertParam(String param) {
+        HttpRequestParam httpRequestParam = new HttpRequestParam();
+
+        Pattern patternOne = Pattern.compile(HTTP_METHODS + " " + URL + " " + REQUEST_BODY);
+        Pattern patternTwo = Pattern.compile(HTTP_METHODS + " " + URL);
+        Pattern patternThree = Pattern.compile(URL);
+
+        List<Pattern> allowedPatterns = Arrays.asList(patternOne, patternTwo, patternThree);
+
+        Matcher matcher;
+        for (Pattern pattern : allowedPatterns) {
+            matcher = pattern.matcher(param);
+            if (matcher.matches()) {
+                if (matcher.groupCount() == 3) {
+                    httpRequestParam.setHttpMethod(matcher.group(1));
+                    httpRequestParam.setEndpoint(matcher.group(2));
+                    httpRequestParam.setRequestBody(matcher.group(3));
+                }
+                if (matcher.groupCount() == 2) {
+                    httpRequestParam.setHttpMethod(matcher.group(1));
+                    httpRequestParam.setEndpoint(matcher.group(2));
+                }
+                if (matcher.groupCount() == 1) {
+                    httpRequestParam.setHttpMethod("GET");
+                    httpRequestParam.setEndpoint(matcher.group(1));
+                }
+            }
+
+        }
+
+        if (httpRequestParam.getHttpMethod() == null) {
+            throw new RuntimeException("Pattern does not match, please check param format");
+        }
+
+        return httpRequestParam;
+    }
+
+}

--- a/xxl-job-executor-samples/xxl-job-executor-sample-spring/src/main/java/com/xxl/job/executor/service/jobhandler/HttpJobHandler.java
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-spring/src/main/java/com/xxl/job/executor/service/jobhandler/HttpJobHandler.java
@@ -4,6 +4,8 @@ import com.xxl.job.core.biz.model.ReturnT;
 import com.xxl.job.core.handler.IJobHandler;
 import com.xxl.job.core.handler.annotation.JobHandler;
 import com.xxl.job.core.log.XxlJobLogger;
+import com.xxl.job.executor.service.jobhandler.param.HttpRequestParam;
+import com.xxl.job.executor.service.jobhandler.param.HttpRequestParamHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.BufferedReader;
@@ -28,11 +30,12 @@ public class HttpJobHandler extends IJobHandler {
         BufferedReader bufferedReader = null;
         try {
             // connection
-            URL realUrl = new URL(param);
+            HttpRequestParam httpRequestParam = HttpRequestParamHandler.getInstance().convertParam(param);
+            URL realUrl = new URL(httpRequestParam.getEndpoint());
             connection = (HttpURLConnection) realUrl.openConnection();
 
             // connection setting
-            connection.setRequestMethod("GET");
+            connection.setRequestMethod(httpRequestParam.getHttpMethod());
             connection.setDoOutput(true);
             connection.setDoInput(true);
             connection.setUseCaches(false);

--- a/xxl-job-executor-samples/xxl-job-executor-sample-spring/src/main/java/com/xxl/job/executor/service/jobhandler/HttpJobHandler.java
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-spring/src/main/java/com/xxl/job/executor/service/jobhandler/HttpJobHandler.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
@@ -44,6 +45,12 @@ public class HttpJobHandler extends IJobHandler {
             connection.setRequestProperty("connection", "Keep-Alive");
             connection.setRequestProperty("Content-Type", "application/json;charset=UTF-8");
             connection.setRequestProperty("Accept-Charset", "application/json;charset=UTF-8");
+
+            if (httpRequestParam.getRequestBody() != null) {
+                OutputStream outputStream = connection.getOutputStream();
+                byte[] requestBody = httpRequestParam.getRequestBody().getBytes("UTF-8");
+                outputStream.write(requestBody, 0 , requestBody.length);
+            }
 
             // do connection
             connection.connect();

--- a/xxl-job-executor-samples/xxl-job-executor-sample-spring/src/main/java/com/xxl/job/executor/service/jobhandler/param/HttpRequestParam.java
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-spring/src/main/java/com/xxl/job/executor/service/jobhandler/param/HttpRequestParam.java
@@ -1,0 +1,32 @@
+package com.xxl.job.executor.service.jobhandler.param;
+
+
+public class HttpRequestParam {
+    private String httpMethod;
+    private String endpoint;
+    private String requestBody;
+
+    public String getHttpMethod() {
+        return httpMethod;
+    }
+
+    public void setHttpMethod(String httpMethod) {
+        this.httpMethod = httpMethod;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public String getRequestBody() {
+        return requestBody;
+    }
+
+    public void setRequestBody(String requestBody) {
+        this.requestBody = requestBody;
+    }
+}

--- a/xxl-job-executor-samples/xxl-job-executor-sample-spring/src/main/java/com/xxl/job/executor/service/jobhandler/param/HttpRequestParamHandler.java
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-spring/src/main/java/com/xxl/job/executor/service/jobhandler/param/HttpRequestParamHandler.java
@@ -1,0 +1,56 @@
+package com.xxl.job.executor.service.jobhandler.param;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class HttpRequestParamHandler {
+    private static final String HTTP_METHODS = "^(GET|PUT|POST|PATCH|DELETE)";
+    private static final String URL = "(https?://[^\\s]+)";
+    private static final String REQUEST_BODY = "(\\{.*})";
+
+    private static final HttpRequestParamHandler instance = new HttpRequestParamHandler();
+
+    public static HttpRequestParamHandler getInstance() {
+        return instance;
+    }
+
+    public HttpRequestParam convertParam(String param) {
+        HttpRequestParam httpRequestParam = new HttpRequestParam();
+
+        Pattern patternOne = Pattern.compile(HTTP_METHODS + " " + URL + " " + REQUEST_BODY);
+        Pattern patternTwo = Pattern.compile(HTTP_METHODS + " " + URL);
+        Pattern patternThree = Pattern.compile(URL);
+
+        List<Pattern> allowedPatterns = Arrays.asList(patternOne, patternTwo, patternThree);
+
+        Matcher matcher;
+        for (Pattern pattern : allowedPatterns) {
+            matcher = pattern.matcher(param);
+            if (matcher.matches()) {
+                if (matcher.groupCount() == 3) {
+                    httpRequestParam.setHttpMethod(matcher.group(1));
+                    httpRequestParam.setEndpoint(matcher.group(2));
+                    httpRequestParam.setRequestBody(matcher.group(3));
+                }
+                if (matcher.groupCount() == 2) {
+                    httpRequestParam.setHttpMethod(matcher.group(1));
+                    httpRequestParam.setEndpoint(matcher.group(2));
+                }
+                if (matcher.groupCount() == 1) {
+                    httpRequestParam.setHttpMethod("GET");
+                    httpRequestParam.setEndpoint(matcher.group(1));
+                }
+            }
+
+        }
+
+        if (httpRequestParam.getHttpMethod() == null) {
+            throw new RuntimeException("Pattern does not match, please check param format");
+        }
+
+        return httpRequestParam;
+    }
+
+}

--- a/xxl-job-executor-samples/xxl-job-executor-sample-springboot/src/main/java/com/xxl/job/executor/service/jobhandler/HttpJobHandler.java
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-springboot/src/main/java/com/xxl/job/executor/service/jobhandler/HttpJobHandler.java
@@ -4,6 +4,8 @@ import com.xxl.job.core.biz.model.ReturnT;
 import com.xxl.job.core.handler.IJobHandler;
 import com.xxl.job.core.handler.annotation.JobHandler;
 import com.xxl.job.core.log.XxlJobLogger;
+import com.xxl.job.executor.service.jobhandler.param.HttpRequestParam;
+import com.xxl.job.executor.service.jobhandler.param.HttpRequestParamHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.BufferedReader;
@@ -28,11 +30,12 @@ public class HttpJobHandler extends IJobHandler {
         BufferedReader bufferedReader = null;
         try {
             // connection
-            URL realUrl = new URL(param);
+            HttpRequestParam httpRequestParam = HttpRequestParamHandler.getInstance().convertParam(param);
+            URL realUrl = new URL(httpRequestParam.getEndpoint());
             connection = (HttpURLConnection) realUrl.openConnection();
 
             // connection setting
-            connection.setRequestMethod("GET");
+            connection.setRequestMethod(httpRequestParam.getHttpMethod());
             connection.setDoOutput(true);
             connection.setDoInput(true);
             connection.setUseCaches(false);

--- a/xxl-job-executor-samples/xxl-job-executor-sample-springboot/src/main/java/com/xxl/job/executor/service/jobhandler/HttpJobHandler.java
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-springboot/src/main/java/com/xxl/job/executor/service/jobhandler/HttpJobHandler.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
@@ -44,6 +45,12 @@ public class HttpJobHandler extends IJobHandler {
             connection.setRequestProperty("connection", "Keep-Alive");
             connection.setRequestProperty("Content-Type", "application/json;charset=UTF-8");
             connection.setRequestProperty("Accept-Charset", "application/json;charset=UTF-8");
+
+            if (httpRequestParam.getRequestBody() != null) {
+                OutputStream outputStream = connection.getOutputStream();
+                byte[] requestBody = httpRequestParam.getRequestBody().getBytes("UTF-8");
+                outputStream.write(requestBody, 0 , requestBody.length);
+            }
 
             // do connection
             connection.connect();

--- a/xxl-job-executor-samples/xxl-job-executor-sample-springboot/src/main/java/com/xxl/job/executor/service/jobhandler/param/HttpRequestParam.java
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-springboot/src/main/java/com/xxl/job/executor/service/jobhandler/param/HttpRequestParam.java
@@ -1,0 +1,32 @@
+package com.xxl.job.executor.service.jobhandler.param;
+
+
+public class HttpRequestParam {
+    private String httpMethod;
+    private String endpoint;
+    private String requestBody;
+
+    public String getHttpMethod() {
+        return httpMethod;
+    }
+
+    public void setHttpMethod(String httpMethod) {
+        this.httpMethod = httpMethod;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public String getRequestBody() {
+        return requestBody;
+    }
+
+    public void setRequestBody(String requestBody) {
+        this.requestBody = requestBody;
+    }
+}

--- a/xxl-job-executor-samples/xxl-job-executor-sample-springboot/src/main/java/com/xxl/job/executor/service/jobhandler/param/HttpRequestParamHandler.java
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-springboot/src/main/java/com/xxl/job/executor/service/jobhandler/param/HttpRequestParamHandler.java
@@ -1,0 +1,56 @@
+package com.xxl.job.executor.service.jobhandler.param;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class HttpRequestParamHandler {
+    private static final String HTTP_METHODS = "^(GET|PUT|POST|PATCH|DELETE)";
+    private static final String URL = "(https?://[^\\s]+)";
+    private static final String REQUEST_BODY = "(\\{.*})";
+
+    private static final HttpRequestParamHandler instance = new HttpRequestParamHandler();
+
+    public static HttpRequestParamHandler getInstance() {
+        return instance;
+    }
+
+    public HttpRequestParam convertParam(String param) {
+        HttpRequestParam httpRequestParam = new HttpRequestParam();
+
+        Pattern patternOne = Pattern.compile(HTTP_METHODS + " " + URL + " " + REQUEST_BODY);
+        Pattern patternTwo = Pattern.compile(HTTP_METHODS + " " + URL);
+        Pattern patternThree = Pattern.compile(URL);
+
+        List<Pattern> allowedPatterns = Arrays.asList(patternOne, patternTwo, patternThree);
+
+        Matcher matcher;
+        for (Pattern pattern : allowedPatterns) {
+            matcher = pattern.matcher(param);
+            if (matcher.matches()) {
+                if (matcher.groupCount() == 3) {
+                    httpRequestParam.setHttpMethod(matcher.group(1));
+                    httpRequestParam.setEndpoint(matcher.group(2));
+                    httpRequestParam.setRequestBody(matcher.group(3));
+                }
+                if (matcher.groupCount() == 2) {
+                    httpRequestParam.setHttpMethod(matcher.group(1));
+                    httpRequestParam.setEndpoint(matcher.group(2));
+                }
+                if (matcher.groupCount() == 1) {
+                    httpRequestParam.setHttpMethod("GET");
+                    httpRequestParam.setEndpoint(matcher.group(1));
+                }
+            }
+
+        }
+
+        if (httpRequestParam.getHttpMethod() == null) {
+            throw new RuntimeException("Pattern does not match, please check param format");
+        }
+
+        return httpRequestParam;
+    }
+
+}

--- a/xxl-job-executor-samples/xxl-job-executor-sample-springboot/src/test/java/com/xxl/job/executor/service/jobhandler/param/HttpRequestParamHandlerTest.java
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-springboot/src/test/java/com/xxl/job/executor/service/jobhandler/param/HttpRequestParamHandlerTest.java
@@ -1,0 +1,73 @@
+package com.xxl.job.executor.service.jobhandler.param;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.http.HttpMethod;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class HttpRequestParamHandlerTest {
+    private HttpRequestParamHandler httpRequestParamHandler;
+
+    @Before
+    public void setUp() throws Exception {
+        httpRequestParamHandler = new HttpRequestParamHandler();
+    }
+
+    @Test
+    public void shouldConvertParamForPatternOne() {
+        //given
+        String param = "POST https://example.com:8082/cron-jobs {\"actionType\": \"create\"}";
+
+        //when
+
+        HttpRequestParam httpRequestParam = httpRequestParamHandler.convertParam(param);
+
+
+        //then
+        assertThat(httpRequestParam.getHttpMethod(), is("POST"));
+        assertThat(httpRequestParam.getEndpoint(), is("https://example.com:8082/cron-jobs"));
+        assertThat(httpRequestParam.getRequestBody(), is("{\"actionType\": \"create\"}"));
+    }
+
+    @Test
+    public void shouldConvertParamForPatternTwo() {
+        //given
+        String param = "PUT http://example.com:8082/cron-jobs";
+
+        //when
+
+        HttpRequestParam httpRequestParam = httpRequestParamHandler.convertParam(param);
+
+
+        //then
+        assertThat(httpRequestParam.getHttpMethod(), is("PUT"));
+        assertThat(httpRequestParam.getEndpoint(), is("http://example.com:8082/cron-jobs"));
+    }
+
+    @Test
+    public void shouldConvertParamForPatternThree() {
+        //given
+        String param = "https://example.com:8082/cron-jobs";
+
+        //when
+
+        HttpRequestParam httpRequestParam = httpRequestParamHandler.convertParam(param);
+
+
+        //then
+        assertThat(httpRequestParam.getHttpMethod(), is("GET"));
+        assertThat(httpRequestParam.getEndpoint(), is("https://example.com:8082/cron-jobs"));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void shouldThrowExceptionWhenPatternDoesNotSupport() {
+        //given
+        String param = "POST https://example.com:8082/cron-jobs \"{\"actionType\": \"create\"}\" something else";
+
+        //when
+
+        HttpRequestParam httpRequestParam = httpRequestParamHandler.convertParam(param);
+    }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**
* 重构HttpJobHandler代码，增加对http各种常见method（e.g：POST|PUT|PATCH|GET|DELETE）的支持，方便采用Restful风格设计API的团队，暴露任务接口。
* 支持现有多个执行器，比如Jfinal、frameless、jboot、nutz等执行器实现

**Other information:**