### PR TITLE
Nginx 不支持“_”符号，导致Token 验证失效

### DIFF
--- a/xxl-job-core/src/main/java/com/xxl/job/core/util/XxlJobRemotingUtil.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/util/XxlJobRemotingUtil.java
@@ -17,7 +17,7 @@ import java.util.Map;
  */
 public class XxlJobRemotingUtil {
     private static Logger logger = LoggerFactory.getLogger(XxlJobRemotingUtil.class);
-    public static String XXL_RPC_ACCESS_TOKEN = "XXL_RPC_ACCESS_TOKEN";
+    public static String XXL_RPC_ACCESS_TOKEN = "XXL-RPC-ACCESS-TOKEN";
 
     /**
      * post


### PR DESCRIPTION
nginx 会默认过滤“_”符号，导致Token失效，无法从 Request header 中 正常获取到Token值。

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**


**Other information:**