### PR TITLE
修复bug: 执行器线程阻塞时给管理器返回的json中有特殊符号，导致管理器端一直报错, 使用getBytes utf-8即可。

### DIFF
--- a/xxl-job-core/src/main/java/com/xxl/job/core/util/XxlJobRemotingUtil.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/util/XxlJobRemotingUtil.java
@@ -57,7 +57,7 @@ public class XxlJobRemotingUtil {
             String requestBody = BasicJson.toJson(requestObj);
 
             DataOutputStream dataOutputStream = new DataOutputStream(connection.getOutputStream());
-            dataOutputStream.writeBytes(requestBody);
+            dataOutputStream.write(requestBody.getBytes("UTF-8"));
             dataOutputStream.flush();
             dataOutputStream.close();
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**

改为getBytes，后面读取就不会出现中文问题了。

**Other information:**