### PR TITLE
注解去掉 default ""，必须指定任务名称。

### DIFF
--- a/xxl-job-core/src/main/java/com/xxl/job/core/handler/annotation/JobHandler.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/handler/annotation/JobHandler.java
@@ -19,6 +19,6 @@ import java.lang.annotation.Target;
 @Deprecated
 public @interface JobHandler {
 
-    String value() default "";
+    String value();
 
 }

--- a/xxl-job-core/src/main/java/com/xxl/job/core/handler/annotation/XxlJob.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/handler/annotation/XxlJob.java
@@ -15,7 +15,7 @@ public @interface XxlJob {
     /**
      * jobhandler name
      */
-    String value() default "";
+    String value();
 
     /**
      * init handler, invoked when JobThread init


### PR DESCRIPTION
内部逻辑上要求必须指定任务名称，和注解上的 `default ""` 冲突，因此去掉。

去掉之后，如果不指定名称，会直接提示编译错误，能更好的体现该名称的含义。

>虽然纯代码来看有一点点不兼容，但是因为业务逻辑有限制，因此直接去掉不会对业务产生任何影响，可以直接升级。