### PR TITLE
添加sql脚本执行的字符编码

### DIFF
--- a/doc/db/tables_xxl_job.sql
+++ b/doc/db/tables_xxl_job.sql
@@ -5,6 +5,7 @@
 CREATE database if NOT EXISTS `xxl_job` default character set utf8mb4 collate utf8mb4_unicode_ci;
 use `xxl_job`;
 
+SET NAMES UTF8;
 
 CREATE TABLE `xxl_job_info` (
   `id` int(11) NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
我在将/doc/db/tables_xxl_job.sql放到dockerfile中运行时候发生了一些意外。

```
FROM mysql:5.7
RUN ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
COPY ./tables_xxl_job.sql /docker-entrypoint-initdb.d
```

在启动docker容器时候发生错误：

> /usr/local/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/tables_xxl_job.sql
> mysql: [Warning] Using a password on the command line interface can be insecure.
> ERROR 1406 (22001) at line 104: Data too long for column 'title' at row 1

在sql脚本中添加 `SET NAMES UTF8;` 之后就可以正常通过了。

