### PR TITLE
修复docker参数不生效的bug

### DIFF
--- a/xxl-job-admin/Dockerfile
+++ b/xxl-job-admin/Dockerfile
@@ -8,4 +8,4 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 ADD target/xxl-job-admin-*.jar /app.jar
 
-ENTRYPOINT ["sh","-c","java -jar /app.jar $PARAMS"]
+ENTRYPOINT ["sh","-c","java $PARAMS -jar /app.jar"]


### PR DESCRIPTION
修复dockerfile启动参数位置不正确，导致JVM参数不生效