### PR TITLE
有些情况下bean为null,需要过滤null

### DIFF
--- a/xxl-job-core/src/main/java/com/xxl/job/core/executor/impl/XxlJobSpringExecutor.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/executor/impl/XxlJobSpringExecutor.java
@@ -81,6 +81,7 @@ public class XxlJobSpringExecutor extends XxlJobExecutor implements ApplicationC
         if (beanDefinitionNames!=null && beanDefinitionNames.length>0) {
             for (String beanDefinitionName : beanDefinitionNames) {
                 Object bean = applicationContext.getBean(beanDefinitionName);
+                if (bean == null) continue;
                 Method[] methods = bean.getClass().getDeclaredMethods();
                 for (Method method: methods) {
                     XxlJob xxlJob = AnnotationUtils.findAnnotation(method, XxlJob.class);


### PR DESCRIPTION

-  Bugfix

 Object bean = applicationContext.getBean(beanDefinitionName);
beanDefinitionName like "org.springframework.beans.factory.config.MethodInvokingFactoryBean#0" would result in null for bean.


**Other information:**