### PR TITLE
add javax.annotation-api dependency to xxl-job-core/pom.xml

### DIFF
--- a/xxl-job-core/pom.xml
+++ b/xxl-job-core/pom.xml
@@ -45,6 +45,13 @@
 			<scope>test</scope>
 		</dependency>
 
+		<!-- javax.annotation -->
+		<dependency>
+			<groupId>javax.annotation</groupId>
+			<artifactId>javax.annotation-api</artifactId>
+			<version>1.3.2</version>
+		</dependency>
+
 	</dependencies>
 
 </project>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [X] Build-related changes
- [ ] Other, please describe:

**The description of the PR:**

The class `com.xxl.job.core.glue.impl.SpringGlueFactory` imports
`javax.annotation.Resource`, which requires the annotation API.  This commit
adds this dependency to the Maven build.

**Other information:**