### PR TITLE
dao层转为jpa代码，不对逻辑层进行更改，并新增可以自定义数据库前缀

### DIFF
--- a/doc/db/init.sql
+++ b/doc/db/init.sql
@@ -1,0 +1,7 @@
+CREATE TABLE xxl_job_lock (
+                              lock_name varchar(50) NOT NULL,
+                              PRIMARY KEY (lock_name)
+);
+
+INSERT INTO xxl_job_lock ( lock_name) VALUES ( 'schedule_lock');
+INSERT INTO kaifa_job_user(id, username, password, role, permission) VALUES (1, 'admin', 'e10adc3949ba59abbe56e057f20f883e', 1, NULL);

--- a/doc/db/init.sql
+++ b/doc/db/init.sql
@@ -4,4 +4,4 @@ CREATE TABLE xxl_job_lock (
 );
 
 INSERT INTO xxl_job_lock ( lock_name) VALUES ( 'schedule_lock');
-INSERT INTO kaifa_job_user(id, username, password, role, permission) VALUES (1, 'admin', 'e10adc3949ba59abbe56e057f20f883e', 1, NULL);
+INSERT INTO xxl_job_user(id, username, password, role, permission) VALUES (1, 'admin', 'e10adc3949ba59abbe56e057f20f883e', 1, NULL);

--- a/doc/db/tables_xxl_job.sql
+++ b/doc/db/tables_xxl_job.sql
@@ -109,6 +109,13 @@ CREATE TABLE `xxl_job_lock` (
   PRIMARY KEY (`lock_name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+CREATE TABLE `xxl_primary_key_gen`
+(
+    `gen_name`  varchar(255) NOT NULL,
+    PRIMARY KEY (`gen_name`),
+    `gen_value` bigint NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 
 INSERT INTO `xxl_job_group`(`id`, `app_name`, `title`, `address_type`, `address_list`) VALUES (1, 'xxl-job-executor-sample', '示例执行器', 0, NULL);
 INSERT INTO `xxl_job_info`(`id`, `job_group`, `job_cron`, `job_desc`, `add_time`, `update_time`, `author`, `alarm_email`, `executor_route_strategy`, `executor_handler`, `executor_param`, `executor_block_strategy`, `executor_timeout`, `executor_fail_retry_count`, `glue_type`, `glue_source`, `glue_remark`, `glue_updatetime`, `child_jobid`) VALUES (1, 1, '0 0 0 * * ? *', '测试任务1', '2018-11-03 22:21:31', '2018-11-03 22:21:31', 'XXL', '', 'FIRST', 'demoJobHandler', '', 'SERIAL_EXECUTION', 0, 0, 'BEAN', '', 'GLUE代码初始化', '2018-11-03 22:21:31', '');

--- a/xxl-job-admin/pom.xml
+++ b/xxl-job-admin/pom.xml
@@ -73,6 +73,11 @@
 			<version>${project.parent.version}</version>
 		</dependency>
 
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/controller/JobGroupController.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/controller/JobGroupController.java
@@ -8,6 +8,7 @@ import com.xxl.job.admin.dao.XxlJobInfoDao;
 import com.xxl.job.admin.dao.XxlJobRegistryDao;
 import com.xxl.job.core.biz.model.ReturnT;
 import com.xxl.job.core.enums.RegistryConfig;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -46,8 +47,9 @@ public class JobGroupController {
 										String appname, String title) {
 
 		// page query
-		List<XxlJobGroup> list = xxlJobGroupDao.pageList(start, length, appname, title);
-		int list_count = xxlJobGroupDao.pageListCount(start, length, appname, title);
+		Page<XxlJobGroup> page = xxlJobGroupDao.pageList(start, length, appname, title);
+		List<XxlJobGroup> list = page.getContent();
+		int list_count = (int) page.getTotalElements();
 
 		// package result
 		Map<String, Object> maps = new HashMap<String, Object>();

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/controller/JobLogController.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/controller/JobLogController.java
@@ -17,6 +17,7 @@ import com.xxl.job.core.biz.model.ReturnT;
 import com.xxl.job.core.util.DateUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -105,8 +106,9 @@ public class JobLogController {
 		}
 		
 		// page query
-		List<XxlJobLog> list = xxlJobLogDao.pageList(start, length, jobGroup, jobId, triggerTimeStart, triggerTimeEnd, logStatus);
-		int list_count = xxlJobLogDao.pageListCount(start, length, jobGroup, jobId, triggerTimeStart, triggerTimeEnd, logStatus);
+		Page<XxlJobLog> page = xxlJobLogDao.pageList(start, length, jobGroup, jobId, triggerTimeStart, triggerTimeEnd, logStatus);
+		List<XxlJobLog> list = page.getContent();
+		int list_count = (int) page.getTotalElements();
 		
 		// package result
 		Map<String, Object> maps = new HashMap<String, Object>();

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/controller/UserController.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/controller/UserController.java
@@ -8,6 +8,7 @@ import com.xxl.job.admin.dao.XxlJobGroupDao;
 import com.xxl.job.admin.dao.XxlJobUserDao;
 import com.xxl.job.admin.service.LoginService;
 import com.xxl.job.core.biz.model.ReturnT;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.util.DigestUtils;
@@ -53,8 +54,9 @@ public class UserController {
                                         String username, int role) {
 
         // page list
-        List<XxlJobUser> list = xxlJobUserDao.pageList(start, length, username, role);
-        int list_count = xxlJobUserDao.pageListCount(start, length, username, role);
+        Page<XxlJobUser> page = xxlJobUserDao.pageList(start, length, username, role);
+        List<XxlJobUser> list = page.getContent();
+        int list_count = (int) page.getTotalElements();
 
         // package result
         Map<String, Object> maps = new HashMap<String, Object>();

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/conf/MysqlConfig.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/conf/MysqlConfig.java
@@ -1,0 +1,16 @@
+package com.xxl.job.admin.core.conf;
+
+import org.hibernate.dialect.MySQL5Dialect;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author YunSongLiu
+ */
+@Component
+public class MysqlConfig extends MySQL5Dialect {
+
+    @Override
+    public String getTableTypeString() {
+        return "ENGINE=InnoDB DEFAULT CHARSET=utf8";
+    }
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/conf/TableNameStrategy.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/conf/TableNameStrategy.java
@@ -1,0 +1,24 @@
+package com.xxl.job.admin.core.conf;
+
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.orm.jpa.hibernate.SpringPhysicalNamingStrategy;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author YunSongLiu
+ */
+@Component
+public class TableNameStrategy extends SpringPhysicalNamingStrategy {
+
+    @Override
+    public Identifier toPhysicalTableName(Identifier name, JdbcEnvironment jdbcEnvironment) {
+        String tableName = tableNamePrefix + "_" + name.getText();
+        return Identifier.toIdentifier(tableName);
+    }
+
+    @Value("${xxl.tablename.prefix:xxl}")
+    private String tableNamePrefix;
+
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/conf/XxlJobAdminConfig.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/conf/XxlJobAdminConfig.java
@@ -5,6 +5,7 @@ import com.xxl.job.admin.core.scheduler.XxlJobScheduler;
 import com.xxl.job.admin.dao.*;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Component;
@@ -75,7 +76,7 @@ public class XxlJobAdminConfig implements InitializingBean, DisposableBean {
     private XxlJobInfoDao xxlJobInfoDao;
     @Resource
     private XxlJobRegistryDao xxlJobRegistryDao;
-    @Resource
+    @Autowired
     private XxlJobGroupDao xxlJobGroupDao;
     @Resource
     private XxlJobLogReportDao xxlJobLogReportDao;

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/conf/XxlJobAdminConfig.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/conf/XxlJobAdminConfig.java
@@ -62,6 +62,9 @@ public class XxlJobAdminConfig implements InitializingBean, DisposableBean {
     @Value("${xxl.job.triggerpool.fast.max}")
     private int triggerPoolFastMax;
 
+    @Value("${xxl.tablename.prefix:xxl}")
+    private String tableNamePrefix;
+
     @Value("${xxl.job.triggerpool.slow.max}")
     private int triggerPoolSlowMax;
 
@@ -97,6 +100,10 @@ public class XxlJobAdminConfig implements InitializingBean, DisposableBean {
 
     public String getAccessToken() {
         return accessToken;
+    }
+
+    public String getTableNamePrefix() {
+        return tableNamePrefix;
     }
 
     public String getEmailUserName() {

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobGroup.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobGroup.java
@@ -11,21 +11,28 @@ import java.util.List;
  * Created by xuxueli on 16/9/30.
  */
 @Entity
-@Table(name = "xxl_job_group")
+@Table(name = "job_group")
 @Proxy(lazy=false)
+@TableGenerator(name = "job_group_gen",
+        table="primary_key_gen",
+        pkColumnName="gen_name",
+        valueColumnName="gen_value",
+        pkColumnValue="JOB_GROUP_PK",
+        allocationSize=1
+)
 public class XxlJobGroup {
 
     @Id
-    @GeneratedValue(strategy=GenerationType.IDENTITY)
-    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.TABLE,generator="job_group_gen")
+    @Column(name = "id",length = 11,nullable = false)
     private Integer id;
-    @Column(name = "app_name")
+    @Column(name = "app_name",length = 64,nullable = false)
     private String appname;
-    @Column(name = "title")
+    @Column(name = "title",length = 12,nullable = false)
     private String title;
-    @Column(name = "address_type")
+    @Column(name = "address_type",length = 4,nullable = false)
     private int addressType;        // 执行器地址类型：0=自动注册、1=手动录入
-    @Column(name = "address_list")
+    @Column(name = "address_list",length = 512)
     private String addressList;     // 执行器地址列表，多地址逗号分隔(手动录入)
 
     // registry list

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobGroup.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobGroup.java
@@ -1,5 +1,8 @@
 package com.xxl.job.admin.core.model;
 
+import org.hibernate.annotations.Proxy;
+
+import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -7,15 +10,26 @@ import java.util.List;
 /**
  * Created by xuxueli on 16/9/30.
  */
+@Entity
+@Table(name = "xxl_job_group")
+@Proxy(lazy=false)
 public class XxlJobGroup {
 
-    private int id;
+    @Id
+    @GeneratedValue(strategy=GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Integer id;
+    @Column(name = "app_name")
     private String appname;
+    @Column(name = "title")
     private String title;
+    @Column(name = "address_type")
     private int addressType;        // 执行器地址类型：0=自动注册、1=手动录入
+    @Column(name = "address_list")
     private String addressList;     // 执行器地址列表，多地址逗号分隔(手动录入)
 
     // registry list
+    @Transient
     private List<String> registryList;  // 执行器地址列表(系统注册)
     public List<String> getRegistryList() {
         if (addressList!=null && addressList.trim().length()>0) {

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobInfo.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobInfo.java
@@ -1,5 +1,8 @@
 package com.xxl.job.admin.core.model;
 
+import org.hibernate.annotations.Proxy;
+
+import javax.persistence.*;
 import java.util.Date;
 
 /**
@@ -7,36 +10,61 @@ import java.util.Date;
  *
  * @author xuxueli  2016-1-12 18:25:49
  */
+@Entity
+@Table(name = "xxl_job_info")
+@Proxy(lazy=false)
 public class XxlJobInfo {
-	
-	private int id;				// 主键ID
-	
-	private int jobGroup;		// 执行器主键ID
+
+	@Id
+	@GeneratedValue(strategy= GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Integer id;				// 主键ID
+
+	@Column(name = "job_group")
+	private Integer jobGroup;		// 执行器主键ID
+
+	@Column(name = "job_cron")
 	private String jobCron;		// 任务执行CRON表达式
+	@Column(name = "job_desc")
 	private String jobDesc;
-	
+
+	@Column(name = "add_time")
 	private Date addTime;
+	@Column(name = "update_time")
 	private Date updateTime;
-	
+
+	@Column(name = "author")
 	private String author;		// 负责人
+
+	@Column(name = "alarm_email")
 	private String alarmEmail;	// 报警邮件
-
+	@Column(name = "executor_route_strategy")
 	private String executorRouteStrategy;	// 执行器路由策略
+	@Column(name = "executor_handler")
 	private String executorHandler;		    // 执行器，任务Handler名称
+	@Column(name = "executor_param")
 	private String executorParam;		    // 执行器，任务参数
+	@Column(name = "executor_block_strategy")
 	private String executorBlockStrategy;	// 阻塞处理策略
+	@Column(name = "executor_timeout")
 	private int executorTimeout;     		// 任务执行超时时间，单位秒
+	@Column(name = "executor_fail_retry_count")
 	private int executorFailRetryCount;		// 失败重试次数
-	
+	@Column(name = "glue_type")
 	private String glueType;		// GLUE类型	#com.xxl.job.core.glue.GlueTypeEnum
+	@Column(name = "glue_source")
 	private String glueSource;		// GLUE源代码
+	@Column(name = "glue_remark")
 	private String glueRemark;		// GLUE备注
+	@Column(name = "glue_updatetime")
 	private Date glueUpdatetime;	// GLUE更新时间
-
+	@Column(name = "child_jobid")
 	private String childJobId;		// 子任务ID，多个逗号分隔
-
+	@Column(name = "trigger_status")
 	private int triggerStatus;		// 调度状态：0-停止，1-运行
+	@Column(name = "trigger_last_time")
 	private long triggerLastTime;	// 上次调度时间
+	@Column(name = "trigger_next_time")
 	private long triggerNextTime;	// 下次调度时间
 
 

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobInfo.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobInfo.java
@@ -11,21 +11,28 @@ import java.util.Date;
  * @author xuxueli  2016-1-12 18:25:49
  */
 @Entity
-@Table(name = "xxl_job_info")
+@Table(name = "job_info")
 @Proxy(lazy=false)
+@TableGenerator(name = "job_info_gen",
+		table="primary_key_gen",
+		pkColumnName="gen_name",
+		valueColumnName="gen_value",
+		pkColumnValue="JOB_INFO_PK",
+		allocationSize=1
+)
 public class XxlJobInfo {
 
 	@Id
-	@GeneratedValue(strategy= GenerationType.IDENTITY)
-	@Column(name = "id")
+	@GeneratedValue(strategy = GenerationType.TABLE,generator="job_info_gen")
+	@Column(name = "id",length = 11,nullable = false)
 	private Integer id;				// 主键ID
 
-	@Column(name = "job_group")
+	@Column(name = "job_group",length = 11,nullable = false)
 	private Integer jobGroup;		// 执行器主键ID
 
-	@Column(name = "job_cron")
+	@Column(name = "job_cron" ,length = 128,nullable = false)
 	private String jobCron;		// 任务执行CRON表达式
-	@Column(name = "job_desc")
+	@Column(name = "job_desc" ,length = 255,nullable = false)
 	private String jobDesc;
 
 	@Column(name = "add_time")
@@ -33,38 +40,39 @@ public class XxlJobInfo {
 	@Column(name = "update_time")
 	private Date updateTime;
 
-	@Column(name = "author")
+	@Column(name = "author",length = 64)
 	private String author;		// 负责人
 
-	@Column(name = "alarm_email")
+	@Column(name = "alarm_email",length = 255)
 	private String alarmEmail;	// 报警邮件
-	@Column(name = "executor_route_strategy")
+	@Column(name = "executor_route_strategy",length = 50)
 	private String executorRouteStrategy;	// 执行器路由策略
-	@Column(name = "executor_handler")
+	@Column(name = "executor_handler",length = 255)
 	private String executorHandler;		    // 执行器，任务Handler名称
-	@Column(name = "executor_param")
+	@Column(name = "executor_param",length = 512)
 	private String executorParam;		    // 执行器，任务参数
-	@Column(name = "executor_block_strategy")
+	@Column(name = "executor_block_strategy",length = 50)
 	private String executorBlockStrategy;	// 阻塞处理策略
-	@Column(name = "executor_timeout")
+	@Column(name = "executor_timeout",length = 11,nullable = false)
 	private int executorTimeout;     		// 任务执行超时时间，单位秒
-	@Column(name = "executor_fail_retry_count")
+	@Column(name = "executor_fail_retry_count",length = 11,nullable = false)
 	private int executorFailRetryCount;		// 失败重试次数
-	@Column(name = "glue_type")
+	@Column(name = "glue_type",length = 50,nullable = false)
 	private String glueType;		// GLUE类型	#com.xxl.job.core.glue.GlueTypeEnum
+	@Lob
 	@Column(name = "glue_source")
 	private String glueSource;		// GLUE源代码
-	@Column(name = "glue_remark")
+	@Column(name = "glue_remark",length = 128)
 	private String glueRemark;		// GLUE备注
 	@Column(name = "glue_updatetime")
 	private Date glueUpdatetime;	// GLUE更新时间
-	@Column(name = "child_jobid")
+	@Column(name = "child_jobid",length = 255)
 	private String childJobId;		// 子任务ID，多个逗号分隔
-	@Column(name = "trigger_status")
+	@Column(name = "trigger_status",length = 4,nullable = false)
 	private int triggerStatus;		// 调度状态：0-停止，1-运行
-	@Column(name = "trigger_last_time")
+	@Column(name = "trigger_last_time",length = 13)
 	private long triggerLastTime;	// 上次调度时间
-	@Column(name = "trigger_next_time")
+	@Column(name = "trigger_next_time",length = 13,nullable = false)
 	private long triggerNextTime;	// 下次调度时间
 
 

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobLock.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobLock.java
@@ -1,0 +1,27 @@
+package com.xxl.job.admin.core.model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+/**
+ * @author YunSongLiu
+ */
+@Entity
+@Table(name = "job_lock")
+public class XxlJobLock {
+
+    @Id
+    @Column(name = "lockName",length = 50)
+    private String lockName;
+
+    public String getLockName() {
+        return lockName;
+    }
+
+    public XxlJobLock setLockName(String lockName) {
+        this.lockName = lockName;
+        return this;
+    }
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobLog.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobLog.java
@@ -10,19 +10,26 @@ import java.util.Date;
  * @author xuxueli  2015-12-19 23:19:09
  */
 @Entity
-@Table(name = "xxl_job_log")
+@Table(name = "job_log")
 @Proxy(lazy=false)
+@TableGenerator(name = "job_log_gen",
+		table="primary_key_gen",
+		pkColumnName="gen_name",
+		valueColumnName="gen_value",
+		pkColumnValue="JOB_LOG_PK",
+		allocationSize=1
+)
 public class XxlJobLog {
 
-	@Column
+	@Column(length = 20,nullable = false)
 	@Id
-	@GeneratedValue(strategy= GenerationType.IDENTITY)
+	@GeneratedValue(strategy = GenerationType.TABLE,generator="job_log_gen")
 	private Long id;
 	
 	// job info
-	@Column(name = "job_group")
+	@Column(name = "job_group",length = 11,nullable = false)
 	private int jobGroup;
-	@Column(name = "job_id")
+	@Column(name = "job_id",length = 11,nullable = false)
 	private int jobId;
 
 	// execute info
@@ -30,31 +37,33 @@ public class XxlJobLog {
 	private String executorAddress;
 	@Column(name = "executor_handler")
 	private String executorHandler;
-	@Column(name = "executor_param")
+	@Column(name = "executor_param",length = 512)
 	private String executorParam;
-	@Column(name = "executor_sharding_param")
+	@Column(name = "executor_sharding_param",length = 20)
 	private String executorShardingParam;
-	@Column(name = "executor_fail_retry_count")
+	@Column(name = "executor_fail_retry_count",length = 11,nullable = false)
 	private int executorFailRetryCount;
 	
 	// trigger info
 	@Column(name = "trigger_time")
 	private Date triggerTime;
-	@Column(name = "trigger_code")
+	@Column(name = "trigger_code",nullable = false,length = 11)
 	private int triggerCode;
+	@Lob
 	@Column(name = "trigger_msg")
 	private String triggerMsg;
 	
 	// handle info
 	@Column(name = "handle_time")
 	private Date handleTime;
-	@Column(name = "handle_code")
+	@Column(name = "handle_code",length = 11,nullable = false)
 	private int handleCode;
+	@Lob
 	@Column(name = "handle_msg")
 	private String handleMsg;
 
 	// alarm info
-	@Column(name = "alarm_status")
+	@Column(name = "alarm_status",length = 4,nullable = false)
 	private int alarmStatus;
 
 	public long getId() {

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobLog.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobLog.java
@@ -1,37 +1,60 @@
 package com.xxl.job.admin.core.model;
 
+import org.hibernate.annotations.Proxy;
+
+import javax.persistence.*;
 import java.util.Date;
 
 /**
  * xxl-job log, used to track trigger process
  * @author xuxueli  2015-12-19 23:19:09
  */
+@Entity
+@Table(name = "xxl_job_log")
+@Proxy(lazy=false)
 public class XxlJobLog {
-	
-	private long id;
+
+	@Column
+	@Id
+	@GeneratedValue(strategy= GenerationType.IDENTITY)
+	private Long id;
 	
 	// job info
+	@Column(name = "job_group")
 	private int jobGroup;
+	@Column(name = "job_id")
 	private int jobId;
 
 	// execute info
+	@Column(name = "executor_address")
 	private String executorAddress;
+	@Column(name = "executor_handler")
 	private String executorHandler;
+	@Column(name = "executor_param")
 	private String executorParam;
+	@Column(name = "executor_sharding_param")
 	private String executorShardingParam;
+	@Column(name = "executor_fail_retry_count")
 	private int executorFailRetryCount;
 	
 	// trigger info
+	@Column(name = "trigger_time")
 	private Date triggerTime;
+	@Column(name = "trigger_code")
 	private int triggerCode;
+	@Column(name = "trigger_msg")
 	private String triggerMsg;
 	
 	// handle info
+	@Column(name = "handle_time")
 	private Date handleTime;
+	@Column(name = "handle_code")
 	private int handleCode;
+	@Column(name = "handle_msg")
 	private String handleMsg;
 
 	// alarm info
+	@Column(name = "alarm_status")
 	private int alarmStatus;
 
 	public long getId() {

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobLogGlue.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobLogGlue.java
@@ -1,19 +1,39 @@
 package com.xxl.job.admin.core.model;
 
+import javax.persistence.*;
 import java.util.Date;
 
 /**
  * xxl-job log for glue, used to track job code process
  * @author xuxueli 2016-5-19 17:57:46
  */
+@Entity
+@Table(name = "job_logglue")
+@TableGenerator(name = "job_logglue_gen",
+		table="primary_key_gen",
+		pkColumnName="gen_name",
+		valueColumnName="gen_value",
+		pkColumnValue="JOB_LOGGLUE_PK",
+		allocationSize=1
+)
 public class XxlJobLogGlue {
-	
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.TABLE,generator="job_logglue_gen")
+	@Column(length = 11,nullable = false)
 	private int id;
+	@Column(name = "job_id",length = 11,nullable = false)
 	private int jobId;				// 任务主键ID
+	@Column(name = "glue_type",length = 50)
 	private String glueType;		// GLUE类型	#com.xxl.job.core.glue.GlueTypeEnum
+	@Lob
+	@Column(name = "glue_source")
 	private String glueSource;
+	@Column(name = "glue_remark",length = 128,nullable = false)
 	private String glueRemark;
+	@Column(name = "add_time")
 	private Date addTime;
+	@Column(name = "update_time")
 	private Date updateTime;
 
 	public int getId() {

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobLogReport.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobLogReport.java
@@ -1,15 +1,32 @@
 package com.xxl.job.admin.core.model;
 
+import javax.persistence.*;
 import java.util.Date;
 
+@Entity
+@Table(name = "job_log_report")
+@TableGenerator(name = "job_log_report_gen",
+        table="primary_key_gen",
+        pkColumnName="gen_name",
+        valueColumnName="gen_value",
+        pkColumnValue="JOB_LOG_REPORT_PK",
+        allocationSize=1
+)
 public class XxlJobLogReport {
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.TABLE,generator="job_log_report_gen")
+    @Column(length = 11,nullable = false)
     private int id;
 
+    @Column(name = "trigger_day")
     private Date triggerDay;
 
+    @Column(name = "running_count",length = 11,nullable = false)
     private int runningCount;
+    @Column(name = "suc_count",length = 11,nullable = false)
     private int sucCount;
+    @Column(name = "fail_count",length = 11,nullable = false)
     private int failCount;
 
     public int getId() {

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobRegistry.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobRegistry.java
@@ -1,16 +1,33 @@
 package com.xxl.job.admin.core.model;
 
+import javax.persistence.*;
 import java.util.Date;
 
 /**
  * Created by xuxueli on 16/9/30.
  */
+@Entity
+@Table(name = "job_registry")
+@TableGenerator(name = "job_registry_gen",
+        table="primary_key_gen",
+        pkColumnName="gen_name",
+        valueColumnName="gen_value",
+        pkColumnValue="JOB_REGISTRY_PK",
+        allocationSize=1
+)
 public class XxlJobRegistry {
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.TABLE,generator="job_registry_gen")
+    @Column(length = 11)
     private int id;
+    @Column(name = "registry_group",length = 50)
     private String registryGroup;
+    @Column(name = "registry_key",length = 255)
     private String registryKey;
+    @Column(name = "registry_value",length = 255)
     private String registryValue;
+    @Column(name = "update_time")
     private Date updateTime;
 
     public int getId() {

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobUser.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobUser.java
@@ -2,15 +2,33 @@ package com.xxl.job.admin.core.model;
 
 import org.springframework.util.StringUtils;
 
+import javax.persistence.*;
+
 /**
  * @author xuxueli 2019-05-04 16:43:12
  */
+@Entity
+@Table(name = "job_user")
+@TableGenerator(name = "job_user_gen",
+		table="primary_key_gen",
+		pkColumnName="gen_name",
+		valueColumnName="gen_value",
+		pkColumnValue="JOB_USER_PK",
+		allocationSize=1
+)
 public class XxlJobUser {
-	
+
+	@Id
+	@Column(length = 11)
+	@GeneratedValue(strategy = GenerationType.TABLE,generator="job_user_gen")
 	private int id;
+	@Column(name = "username",length = 50,nullable = false)
 	private String username;		// 账号
+	@Column(name = "password",length = 50,nullable = false)
 	private String password;		// 密码
+	@Column(name = "role",length = 4,nullable = false)
 	private int role;				// 角色：0-普通用户、1-管理员
+	@Column(name = "permission",length = 255)
 	private String permission;	// 权限：执行器ID列表，多个逗号分割
 
 	public int getId() {

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/thread/JobScheduleHelper.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/thread/JobScheduleHelper.java
@@ -53,6 +53,8 @@ public class JobScheduleHelper {
                 // pre-read count: treadpool-size * trigger-qps (each trigger cost 50ms, qps = 1000/50 = 20)
                 int preReadCount = (XxlJobAdminConfig.getAdminConfig().getTriggerPoolFastMax() + XxlJobAdminConfig.getAdminConfig().getTriggerPoolSlowMax()) * 20;
 
+                String tableNamePrefix = XxlJobAdminConfig.getAdminConfig().getTableNamePrefix();
+
                 while (!scheduleThreadToStop) {
 
                     // Scan Job
@@ -69,7 +71,7 @@ public class JobScheduleHelper {
                         connAutoCommit = conn.getAutoCommit();
                         conn.setAutoCommit(false);
 
-                        preparedStatement = conn.prepareStatement(  "select * from xxl_job_lock where lock_name = 'schedule_lock' for update" );
+                        preparedStatement = conn.prepareStatement(  "select * from " + tableNamePrefix + "_job_lock where lock_name = 'schedule_lock' for update" );
                         preparedStatement.execute();
 
                         // tx start

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobGroupDao.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobGroupDao.java
@@ -2,6 +2,7 @@ package com.xxl.job.admin.dao;
 
 import com.xxl.job.admin.core.model.XxlJobGroup;
 import org.apache.ibatis.annotations.Param;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 
@@ -22,7 +23,7 @@ public interface XxlJobGroupDao {
 
     public XxlJobGroup load(@Param("id") int id);
 
-    public List<XxlJobGroup> pageList(@Param("offset") int offset,
+    public Page<XxlJobGroup> pageList(@Param("offset") int offset,
                                       @Param("pagesize") int pagesize,
                                       @Param("appname") String appname,
                                       @Param("title") String title);

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobGroupDao.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobGroupDao.java
@@ -1,7 +1,6 @@
 package com.xxl.job.admin.dao;
 
 import com.xxl.job.admin.core.model.XxlJobGroup;
-import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
@@ -9,7 +8,6 @@ import java.util.List;
 /**
  * Created by xuxueli on 16/9/30.
  */
-@Mapper
 public interface XxlJobGroupDao {
 
     public List<XxlJobGroup> findAll();

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobInfoDao.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobInfoDao.java
@@ -1,8 +1,8 @@
 package com.xxl.job.admin.dao;
 
 import com.xxl.job.admin.core.model.XxlJobInfo;
-import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 
@@ -11,10 +11,9 @@ import java.util.List;
  * job info
  * @author xuxueli 2016-1-12 18:03:45
  */
-@Mapper
 public interface XxlJobInfoDao {
 
-	public List<XxlJobInfo> pageList(@Param("offset") int offset,
+	public Page<XxlJobInfo> pageList(@Param("offset") int offset,
 									 @Param("pagesize") int pagesize,
 									 @Param("jobGroup") int jobGroup,
 									 @Param("triggerStatus") int triggerStatus,

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobLogDao.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobLogDao.java
@@ -1,8 +1,8 @@
 package com.xxl.job.admin.dao;
 
 import com.xxl.job.admin.core.model.XxlJobLog;
-import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+import org.springframework.data.domain.Page;
 
 import java.util.Date;
 import java.util.List;
@@ -12,11 +12,10 @@ import java.util.Map;
  * job log
  * @author xuxueli 2016-1-12 18:03:06
  */
-@Mapper
 public interface XxlJobLogDao {
 
 	// exist jobId not use jobGroup, not exist use jobGroup
-	public List<XxlJobLog> pageList(@Param("offset") int offset,
+	public Page<XxlJobLog> pageList(@Param("offset") int offset,
 									@Param("pagesize") int pagesize,
 									@Param("jobGroup") int jobGroup,
 									@Param("jobId") int jobId,

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobLogGlueDao.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobLogGlueDao.java
@@ -1,7 +1,6 @@
 package com.xxl.job.admin.dao;
 
 import com.xxl.job.admin.core.model.XxlJobLogGlue;
-import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
@@ -10,7 +9,6 @@ import java.util.List;
  * job log for glue
  * @author xuxueli 2016-5-19 18:04:56
  */
-@Mapper
 public interface XxlJobLogGlueDao {
 	
 	public int save(XxlJobLogGlue xxlJobLogGlue);

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobLogReportDao.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobLogReportDao.java
@@ -1,7 +1,6 @@
 package com.xxl.job.admin.dao;
 
 import com.xxl.job.admin.core.model.XxlJobLogReport;
-import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
 import java.util.Date;
@@ -11,7 +10,6 @@ import java.util.List;
  * job log
  * @author xuxueli 2019-11-22
  */
-@Mapper
 public interface XxlJobLogReportDao {
 
 	public int save(XxlJobLogReport xxlJobLogReport);

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobRegistryDao.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobRegistryDao.java
@@ -1,7 +1,6 @@
 package com.xxl.job.admin.dao;
 
 import com.xxl.job.admin.core.model.XxlJobRegistry;
-import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
 import java.util.Date;
@@ -10,7 +9,6 @@ import java.util.List;
 /**
  * Created by xuxueli on 16/9/30.
  */
-@Mapper
 public interface XxlJobRegistryDao {
 
     public List<Integer> findDead(@Param("timeout") int timeout,

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobUserDao.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobUserDao.java
@@ -1,19 +1,17 @@
 package com.xxl.job.admin.dao;
 
 import com.xxl.job.admin.core.model.XxlJobUser;
-import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
-import java.util.List;
+import org.springframework.data.domain.Page;
 
 /**
  * @author xuxueli 2019-05-04 16:44:59
  */
-@Mapper
 public interface XxlJobUserDao {
 
-	public List<XxlJobUser> pageList(@Param("offset") int offset,
-                                     @Param("pagesize") int pagesize,
-                                     @Param("username") String username,
+	public Page<XxlJobUser> pageList(@Param("offset") int offset,
+									 @Param("pagesize") int pagesize,
+									 @Param("username") String username,
 									 @Param("role") int role);
 	public int pageListCount(@Param("offset") int offset,
 							 @Param("pagesize") int pagesize,

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/impl/XxlJobGroupDaoImpl.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/impl/XxlJobGroupDaoImpl.java
@@ -4,11 +4,19 @@ import com.xxl.job.admin.core.model.XxlJobGroup;
 import com.xxl.job.admin.dao.XxlJobGroupDao;
 import com.xxl.job.admin.repository.XxlJobGroupRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import javax.persistence.EntityManager;
+import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.Predicate;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -19,13 +27,35 @@ public class XxlJobGroupDaoImpl implements XxlJobGroupDao {
 
     @Override
     public List<XxlJobGroup> findAll() {
-        Sort sort = Sort.by(Sort.Direction.ASC,"order");
-        return xxlJobGroupRepository.findAll(sort);
+        return xxlJobGroupRepository.findAll(getGroupSort());
+    }
+
+    @Override
+    public Page<XxlJobGroup> pageList(int offset, int pagesize, String appname, String title) {
+
+        Pageable pageable = PageRequest.of(offset / pagesize, pagesize, getGroupSort());
+        Specification<XxlJobGroup> specification = (Specification<XxlJobGroup>) (root, criteriaQuery, criteriaBuilder) -> {
+            Predicate predicate = criteriaBuilder.conjunction();
+            List<Expression<Boolean>> expressions = predicate.getExpressions();
+            if (!StringUtils.isEmpty(appname)) {
+                expressions.add(criteriaBuilder.equal(root.get("appname"), appname));
+            }
+            if (!StringUtils.isEmpty(title)) {
+                expressions.add(criteriaBuilder.equal(root.get("title"),title));
+            }
+            return predicate;
+        };
+        return xxlJobGroupRepository.findAll(specification,pageable);
+    }
+
+    @Override
+    public int pageListCount(int offset, int pagesize, String appname, String title) {
+        return 0;
     }
 
     @Override
     public List<XxlJobGroup> findByAddressType(int addressType) {
-        return xxlJobGroupRepository.queryXxlJobGroupsByAddressTypeEqualsOrderByIdAsc(addressType);
+        return xxlJobGroupRepository.queryXxlJobGroupsByAddressTypeEquals(addressType,getGroupSort());
     }
 
     @Override
@@ -58,6 +88,13 @@ public class XxlJobGroupDaoImpl implements XxlJobGroupDao {
         entityManager.remove(result);
         entityManager.flush();
         return 1;
+    }
+
+    private Sort getGroupSort(){
+        Sort.Order order1 = new Sort.Order(Sort.Direction.ASC,"appname");
+        Sort.Order order2 = new Sort.Order(Sort.Direction.ASC,"title");
+        Sort.Order order3 = new Sort.Order(Sort.Direction.ASC,"id");
+        return Sort.by(Arrays.asList(order1,order2,order3));
     }
 
     @Override

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/impl/XxlJobGroupDaoImpl.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/impl/XxlJobGroupDaoImpl.java
@@ -1,0 +1,72 @@
+package com.xxl.job.admin.dao.impl;
+
+import com.xxl.job.admin.core.model.XxlJobGroup;
+import com.xxl.job.admin.dao.XxlJobGroupDao;
+import com.xxl.job.admin.repository.XxlJobGroupRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+/**
+ * @author YunSongLiu
+ */
+@Service
+public class XxlJobGroupDaoImpl implements XxlJobGroupDao {
+
+    @Override
+    public List<XxlJobGroup> findAll() {
+        Sort sort = Sort.by(Sort.Direction.ASC,"id");
+        return xxlJobGroupRepository.findAll(sort);
+    }
+
+    @Override
+    public List<XxlJobGroup> findByAddressType(int addressType) {
+        return xxlJobGroupRepository.queryXxlJobGroupsByAddressTypeEqualsOrderByIdAsc(addressType);
+    }
+
+    @Override
+    @Transactional
+    public int save(XxlJobGroup xxlJobGroup) {
+        entityManager.persist(xxlJobGroup);
+        entityManager.flush();
+        return 1;
+    }
+
+    @Override
+    @Transactional
+    public int update(XxlJobGroup xxlJobGroup) {
+        XxlJobGroup result =  load(xxlJobGroup.getId());
+        if (result == null) {
+            return 0;
+        }
+        entityManager.merge(xxlJobGroup);
+        entityManager.flush();
+        return 1;
+    }
+
+    @Override
+    @Transactional
+    public int remove(int id) {
+        XxlJobGroup result =  xxlJobGroupRepository.getOne(id);
+        if (result == null) {
+            return 0;
+        }
+        entityManager.remove(result);
+        entityManager.flush();
+        return 0;
+    }
+
+    @Override
+    public XxlJobGroup load(int id) {
+        return xxlJobGroupRepository.findById(id).orElse(null);
+    }
+
+    @Autowired
+    private XxlJobGroupRepository xxlJobGroupRepository;
+    @Autowired
+    private EntityManager entityManager;
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/impl/XxlJobGroupDaoImpl.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/impl/XxlJobGroupDaoImpl.java
@@ -19,7 +19,7 @@ public class XxlJobGroupDaoImpl implements XxlJobGroupDao {
 
     @Override
     public List<XxlJobGroup> findAll() {
-        Sort sort = Sort.by(Sort.Direction.ASC,"id");
+        Sort sort = Sort.by(Sort.Direction.ASC,"order");
         return xxlJobGroupRepository.findAll(sort);
     }
 
@@ -29,7 +29,7 @@ public class XxlJobGroupDaoImpl implements XxlJobGroupDao {
     }
 
     @Override
-    @Transactional
+    @Transactional(rollbackFor = Exception.class)
     public int save(XxlJobGroup xxlJobGroup) {
         entityManager.persist(xxlJobGroup);
         entityManager.flush();
@@ -37,7 +37,7 @@ public class XxlJobGroupDaoImpl implements XxlJobGroupDao {
     }
 
     @Override
-    @Transactional
+    @Transactional(rollbackFor = Exception.class)
     public int update(XxlJobGroup xxlJobGroup) {
         XxlJobGroup result =  load(xxlJobGroup.getId());
         if (result == null) {
@@ -49,15 +49,15 @@ public class XxlJobGroupDaoImpl implements XxlJobGroupDao {
     }
 
     @Override
-    @Transactional
+    @Transactional(rollbackFor = Exception.class)
     public int remove(int id) {
-        XxlJobGroup result =  xxlJobGroupRepository.getOne(id);
+        XxlJobGroup result =  xxlJobGroupRepository.findById(id).orElse(null);
         if (result == null) {
             return 0;
         }
         entityManager.remove(result);
         entityManager.flush();
-        return 0;
+        return 1;
     }
 
     @Override

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/impl/XxlJobInfoDaoImpl.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/impl/XxlJobInfoDaoImpl.java
@@ -1,0 +1,129 @@
+package com.xxl.job.admin.dao.impl;
+
+import com.xxl.job.admin.core.model.XxlJobInfo;
+import com.xxl.job.admin.dao.XxlJobInfoDao;
+import com.xxl.job.admin.repository.XxlJobInfoRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Scope;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import javax.persistence.EntityManager;
+import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.Predicate;
+import java.util.List;
+
+/**
+ * @author YunSongLiu
+ */
+@Service
+public class XxlJobInfoDaoImpl implements XxlJobInfoDao {
+
+    @Override
+    public Page<XxlJobInfo> pageList(int offset, int pagesize, int jobGroup, int triggerStatus, String jobDesc, String executorHandler, String author) {
+        Pageable pageable = PageRequest.of(offset / pagesize, pagesize, Sort.Direction.DESC, "id");
+        Specification<XxlJobInfo> specification = (Specification<XxlJobInfo>) (root, criteriaQuery, criteriaBuilder) -> {
+            Predicate predicate = criteriaBuilder.conjunction();
+            List<Expression<Boolean>> expressions = predicate.getExpressions();
+            if (jobGroup > 0) {
+                expressions.add(criteriaBuilder.equal(root.get("JobGroup"), jobGroup));
+            }
+            if (triggerStatus > 0) {
+                expressions.add(criteriaBuilder.equal(root.get("triggerStatus"),triggerStatus));
+            }
+            if (!StringUtils.isEmpty(jobDesc)) {
+                expressions.add(criteriaBuilder.like(root.get("jobDesc"),"%" +jobDesc + "%"));
+            }
+            if (!StringUtils.isEmpty(executorHandler)) {
+                expressions.add(criteriaBuilder.like(root.get("executorHandler"),"%" + executorHandler + "%"));
+            }
+            if (!StringUtils.isEmpty(author)) {
+                expressions.add(criteriaBuilder.like(root.get("author"),"%" + author + "%"));
+            }
+            return predicate;
+        };
+
+        return xxlJobInfoRepository.findAll(specification,pageable);
+    }
+
+    @Override
+    public int pageListCount(int offset, int pagesize, int jobGroup, int triggerStatus, String jobDesc, String executorHandler, String author) {
+        return 0;
+    }
+
+    @Override
+    @Transactional
+    @Scope("prototype")
+    public int save(XxlJobInfo info) {
+        entityManager.persist(info);
+        entityManager.flush();
+        return 1;
+    }
+
+    @Override
+    public XxlJobInfo loadById(int id) {
+        return xxlJobInfoRepository.findById(id).orElse(null);
+    }
+
+    @Override
+    @Transactional
+    public int update(XxlJobInfo xxlJobInfo) {
+        if (loadById(xxlJobInfo.getId()) == null){
+            return 0;
+        }
+        entityManager.merge(xxlJobInfo);
+        entityManager.flush();
+        return 1;
+    }
+
+    @Override
+    @Transactional
+    public int delete(long id) {
+        xxlJobInfoRepository.deleteById((int) id);
+        return 1;
+    }
+
+    @Override
+    public List<XxlJobInfo> getJobsByGroup(int jobGroup) {
+        return xxlJobInfoRepository.queryXxlJobInfosByJobGroupEquals(jobGroup);
+    }
+
+    @Override
+    public int findAllCount() {
+        return (int) xxlJobInfoRepository.count();
+    }
+
+    @Override
+    public List<XxlJobInfo> scheduleJobQuery(long maxNextTime, int pagesize) {
+        Pageable pageable = PageRequest.of(0, pagesize, Sort.Direction.ASC, "id");
+        Specification<XxlJobInfo> specification = (Specification<XxlJobInfo>) (root, criteriaQuery, criteriaBuilder) -> {
+            Predicate predicate = criteriaBuilder.conjunction();
+            List<Expression<Boolean>> expressions = predicate.getExpressions();
+            expressions.add(criteriaBuilder.equal(root.get("triggerStatus"), 1));
+            expressions.add(criteriaBuilder.lessThanOrEqualTo(root.get("triggerNextTime"),maxNextTime));
+            return predicate;
+        };
+        return xxlJobInfoRepository.findAll(specification,pageable).getContent();
+    }
+
+    @Override
+    @Transactional
+    public int scheduleUpdate(XxlJobInfo xxlJobInfo) {
+        if (loadById(xxlJobInfo.getId()) == null){
+            return 0;
+        }
+        xxlJobInfoRepository.updateSchedule(xxlJobInfo.getId(),xxlJobInfo.getTriggerLastTime(),xxlJobInfo.getTriggerNextTime(),xxlJobInfo.getTriggerStatus());
+        return 1;
+    }
+
+    @Autowired
+    private XxlJobInfoRepository xxlJobInfoRepository;
+    @Autowired
+    private EntityManager entityManager;
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/impl/XxlJobLogDaoImpl.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/impl/XxlJobLogDaoImpl.java
@@ -1,0 +1,242 @@
+package com.xxl.job.admin.dao.impl;
+
+import com.xxl.job.admin.core.model.XxlJobLog;
+import com.xxl.job.admin.dao.XxlJobLogDao;
+import com.xxl.job.admin.repository.XxlJobLogRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Tuple;
+import javax.persistence.criteria.*;
+import java.util.*;
+
+/**
+ * @author YunSongLiu
+ */
+@Service
+public class XxlJobLogDaoImpl implements XxlJobLogDao {
+
+    @Override
+    public Page<XxlJobLog> pageList(int offset, int pagesize, int jobGroup, int jobId, Date triggerTimeStart, Date triggerTimeEnd, int logStatus) {
+        Pageable pageable = PageRequest.of(offset / pagesize, pagesize, Sort.Direction.DESC, "triggerTime");
+        Specification<XxlJobLog> specification = (Specification<XxlJobLog>) (root, criteriaQuery, criteriaBuilder) -> {
+            Predicate predicate = criteriaBuilder.conjunction();
+            List<Expression<Boolean>> expressions = predicate.getExpressions();
+            if (jobId == 0 && jobGroup > 0) {
+                expressions.add(criteriaBuilder.equal(root.get("jobGroup"), jobGroup));
+            }
+            if (jobId > 0) {
+                expressions.add(criteriaBuilder.equal(root.get("jobId"), jobId));
+            }
+            if (triggerTimeStart != null) {
+                expressions.add(criteriaBuilder.greaterThanOrEqualTo(root.get("triggerTimeStart"), triggerTimeStart));
+            }
+            if (triggerTimeEnd != null) {
+                expressions.add(criteriaBuilder.lessThanOrEqualTo(root.get("triggerTimeEnd"), triggerTimeEnd));
+            }
+            if (logStatus == 1) {
+                expressions.add(criteriaBuilder.equal(root.get("handleCode"), 200));
+            } else if (logStatus == 2) {
+                CriteriaBuilder.In<Object> in1 = criteriaBuilder.in(root.get("triggerCode"));
+                in1.value(200);
+                in1.value(0);
+                CriteriaBuilder.In<Object> in2 = criteriaBuilder.in(root.get("handleCode"));
+                in2.value(200);
+                in2.value(0);
+                expressions.add(criteriaBuilder.or(criteriaBuilder.not(in1), criteriaBuilder.not(in2)));
+            } else if (logStatus == 3) {
+                expressions.add(criteriaBuilder.and(criteriaBuilder.equal(root.get("triggerCode"), 200), criteriaBuilder.equal(root.get("handleCode"), 0)));
+            }
+            return predicate;
+        };
+
+        return xxlJobLogRepository.findAll(specification, pageable);
+    }
+
+    @Override
+    public int pageListCount(int offset, int pagesize, int jobGroup, int jobId, Date triggerTimeStart, Date triggerTimeEnd, int logStatus) {
+        return 0;
+    }
+
+    @Override
+    public XxlJobLog load(long id) {
+        return xxlJobLogRepository.findById(id).orElse(null);
+    }
+
+    @Override
+    @Transactional
+    public long save(XxlJobLog xxlJobLog) {
+        entityManager.persist(xxlJobLog);
+        entityManager.flush();
+        return 1;
+    }
+
+    @Override
+    @Transactional
+    public int updateTriggerInfo(XxlJobLog xxlJobLog) {
+        XxlJobLog data = load(xxlJobLog.getId());
+        if (data == null) {
+            return 1;
+        }
+        data.setTriggerTime(xxlJobLog.getTriggerTime());
+        data.setTriggerCode(xxlJobLog.getTriggerCode());
+        data.setTriggerMsg(xxlJobLog.getTriggerMsg());
+        data.setExecutorAddress(xxlJobLog.getExecutorAddress());
+        data.setExecutorHandler(xxlJobLog.getExecutorHandler());
+        data.setExecutorParam(xxlJobLog.getExecutorParam());
+        data.setExecutorShardingParam(xxlJobLog.getExecutorShardingParam());
+        data.setExecutorFailRetryCount(xxlJobLog.getExecutorFailRetryCount());
+        entityManager.merge(data);
+        entityManager.flush();
+        return 1;
+    }
+
+    @Override
+    @Transactional
+    public int updateHandleInfo(XxlJobLog xxlJobLog) {
+        XxlJobLog data = load(xxlJobLog.getId());
+        if (data == null) {
+            return 1;
+        }
+        data.setHandleTime(xxlJobLog.getHandleTime());
+        data.setHandleCode(xxlJobLog.getHandleCode());
+        data.setHandleMsg(xxlJobLog.getHandleMsg());
+        entityManager.merge(data);
+        entityManager.flush();
+        return 1;
+    }
+
+    @Override
+    @Transactional
+    public int delete(int jobId) {
+        xxlJobLogRepository.deleteXxlJobLogsByJobId(jobId);
+        return 0;
+    }
+
+    @Override
+    public Map<String, Object> findLogReport(Date from, Date to) {
+        CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Tuple> criteriaQuery = criteriaBuilder.createTupleQuery();
+        Root<XxlJobLog> root = criteriaQuery.from(XxlJobLog.class);
+        Path<Integer> handleCode = root.get("handleCode");
+        Path<Integer> triggerCode = root.get("triggerCode");
+        CriteriaBuilder.In<Object> in1 = criteriaBuilder.in(triggerCode);
+        in1.value(200);
+        in1.value(0);
+        criteriaQuery.multiselect(
+                criteriaBuilder.count(handleCode).alias("triggerDayCount"),
+                criteriaBuilder
+                        .sum(criteriaBuilder.selectCase()
+                                .when(criteriaBuilder.and(in1, criteriaBuilder.equal(handleCode, 0)), 1)
+                                .otherwise(0).as(Long.class)).alias("triggerDayCountRunning"),
+                criteriaBuilder.sum(criteriaBuilder.selectCase().when(criteriaBuilder.equal(handleCode, 200), 1).otherwise(0).as(Long.class)).alias("triggerDayCountSuc")
+        ).where(
+                criteriaBuilder.between(root.get("triggerTime"), from, to)
+        );
+        Tuple result = entityManager.createQuery(criteriaQuery).getSingleResult();
+        Map<String,Object> data = new HashMap<>();
+        data.put("triggerDayCount",result.get(0));
+        data.put("triggerDayCountRunning",result.get(1));
+        data.put("triggerTime",result.get(2));
+        return data;
+    }
+
+    @Override
+    public List<Long> findClearLogIds(int jobGroup, int jobId, Date clearBeforeTime, int clearBeforeNum, int pagesize) {
+
+
+
+        CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Long> criteriaQuery = criteriaBuilder.createQuery(Long.class);
+        Root<XxlJobLog> root = criteriaQuery.from(XxlJobLog.class);
+        Predicate predicate = criteriaBuilder.conjunction();
+        List<Expression<Boolean>> expressions = predicate.getExpressions();
+        if (jobGroup > 0) {
+            expressions.add(criteriaBuilder.equal(root.get("jobGroup"), jobGroup));
+        }
+        if (jobId > 0) {
+            expressions.add(criteriaBuilder.equal(root.get("jobId"), jobId));
+        }
+        if (clearBeforeTime != null) {
+            expressions.add(criteriaBuilder.lessThanOrEqualTo(root.get("triggerTime"), clearBeforeTime));
+        }
+        if (clearBeforeNum > 0) {
+            CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+            CriteriaQuery<Long> subQuery = cb.createQuery(Long.class);
+            Root<XxlJobLog> subRoot = subQuery.from(XxlJobLog.class);
+            Predicate subPredicate = cb.conjunction();
+            if (jobGroup > 0) {
+                subPredicate.getExpressions().add(cb.equal(subRoot.get("jobGroup"), jobGroup));
+            }
+            if (jobId > 0) {
+                subPredicate.getExpressions().add(cb.equal(subRoot.get("jobId"), jobId));
+            }
+            subQuery.select(subRoot.get("id").as(Long.class)).where(subPredicate).orderBy(cb.desc(subRoot.get("triggerTime")));
+            List<Long> idList = entityManager.createQuery(subQuery).setMaxResults(clearBeforeNum).getResultList();
+
+            CriteriaBuilder.In<Object> in = criteriaBuilder.in(root.get("id"));
+            in.value(idList);
+
+            expressions.add(criteriaBuilder.not(in));
+        }
+
+        criteriaQuery.select(root.get("id").as(Long.class)).where(predicate).orderBy(criteriaBuilder.asc(root.get("id")));
+        return entityManager.createQuery(criteriaQuery).setMaxResults(pagesize).getResultList();
+    }
+
+    @Override
+    @Transactional
+    public int clearLog(List<Long> logIds) {
+        for (Long id : logIds) {
+            xxlJobLogRepository.deleteById(id);
+        }
+        return 0;
+    }
+
+    @Override
+    public List<Long> findFailJobLogIds(int pagesize) {
+        CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Long> criteriaQuery = criteriaBuilder.createQuery(Long.class);
+        Root<XxlJobLog> root = criteriaQuery.from(XxlJobLog.class);
+        Predicate predicate = criteriaBuilder.conjunction();
+        List<Expression<Boolean>> expressions = predicate.getExpressions();
+        Path<Integer> handleCode = root.get("handleCode");
+        Path<Integer> triggerCode = root.get("triggerCode");
+        CriteriaBuilder.In<Object> in = criteriaBuilder.in(triggerCode);
+        in.value(Arrays.asList(0,200));
+
+        expressions.add(
+                criteriaBuilder.not(
+                        criteriaBuilder.or(
+                                criteriaBuilder.and(in,criteriaBuilder.equal(handleCode,0)),
+                        criteriaBuilder.equal(handleCode,200))));
+
+        expressions.add(criteriaBuilder.equal(root.get("alarmStatus"),0));
+
+        criteriaQuery.select(root.get("id").as(Long.class)).where(predicate).orderBy(criteriaBuilder.asc(root.get("id")));
+
+        return entityManager.createQuery(criteriaQuery).setMaxResults(pagesize).getResultList();
+    }
+
+    @Override
+    @Transactional
+    public int updateAlarmStatus(long logId, int oldAlarmStatus, int newAlarmStatus) {
+        XxlJobLog xxlJobLog = xxlJobLogRepository.queryXxlJobLogByIdEqualsAndAlarmStatusEquals(logId,oldAlarmStatus);
+        xxlJobLog.setAlarmStatus(newAlarmStatus);
+        entityManager.merge(xxlJobLog);
+        entityManager.flush();
+        return 1;
+    }
+
+    @Autowired
+    private XxlJobLogRepository xxlJobLogRepository;
+    @Autowired
+    private EntityManager entityManager;
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/impl/XxlJobLogGlueDaoImpl.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/impl/XxlJobLogGlueDaoImpl.java
@@ -1,0 +1,70 @@
+package com.xxl.job.admin.dao.impl;
+
+import com.xxl.job.admin.core.model.XxlJobLogGlue;
+import com.xxl.job.admin.dao.XxlJobLogGlueDao;
+import com.xxl.job.admin.repository.XxlJobLogGlueRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.criteria.*;
+import java.util.List;
+
+/**
+ * @author YunSongLiu
+ */
+@Service
+public class XxlJobLogGlueDaoImpl implements XxlJobLogGlueDao {
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public int save(XxlJobLogGlue xxlJobLogGlue) {
+        entityManager.persist(xxlJobLogGlue);
+        entityManager.flush();
+        return 1;
+    }
+
+    @Override
+    public List<XxlJobLogGlue> findByJobId(int jobId) {
+        return xxlJobLogGlueRepository.findByJobIdEqualsOrderByIdDesc(jobId);
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public int removeOld(int jobId, int limit) {
+        CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
+        CriteriaDelete<XxlJobLogGlue> criteriaDelete = criteriaBuilder.createCriteriaDelete(XxlJobLogGlue.class);
+        Root<XxlJobLogGlue> root = criteriaDelete.from(XxlJobLogGlue.class);
+        Predicate predicate = criteriaBuilder.conjunction();
+        List<Expression<Boolean>> expressions = predicate.getExpressions();
+
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Integer> subQuery = cb.createQuery(Integer.class);
+        Root<XxlJobLogGlue> subRoot = subQuery.from(XxlJobLogGlue.class);
+        Predicate subPredicate = cb.equal(subRoot.get("jobId"),jobId);
+        Path<Object> updateDate = subRoot.get("updateTime");
+        subQuery.select(subRoot.get("id").as(Integer.class)).where(subPredicate).orderBy(cb.desc(updateDate));
+        List<Integer> idList = entityManager.createQuery(subQuery).setMaxResults(limit).getResultList();
+
+        CriteriaBuilder.In<Object> in = criteriaBuilder.in(root.get("id"));
+        in.value(idList);
+        expressions.add(criteriaBuilder.not(in));
+        criteriaDelete.where(predicate);
+
+        entityManager.createQuery(criteriaDelete).executeUpdate();
+        return 1;
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public int deleteByJobId(int jobId) {
+        xxlJobLogGlueRepository.deleteAllByJobIdEquals(jobId);
+        return 1;
+    }
+
+    @Autowired
+    private EntityManager entityManager;
+    @Autowired
+    private XxlJobLogGlueRepository xxlJobLogGlueRepository;
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/impl/XxlJobLogReportDaoImpl.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/impl/XxlJobLogReportDaoImpl.java
@@ -1,0 +1,78 @@
+package com.xxl.job.admin.dao.impl;
+
+import com.xxl.job.admin.core.model.XxlJobLogReport;
+import com.xxl.job.admin.dao.XxlJobLogReportDao;
+import com.xxl.job.admin.repository.XxlJobLogReportRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Tuple;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * @author YunSongLiu
+ */
+@Service
+public class XxlJobLogReportDaoImpl implements XxlJobLogReportDao {
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public int save(XxlJobLogReport xxlJobLogReport) {
+        entityManager.persist(xxlJobLogReport);
+        return 1;
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public int update(XxlJobLogReport xxlJobLogReport) {
+        XxlJobLogReport data = xxlJobLogReportRepository.findByTriggerDayEquals(xxlJobLogReport.getTriggerDay());
+        if (data == null) {
+            return 0;
+        }
+
+        data.setRunningCount(xxlJobLogReport.getRunningCount());
+        data.setSucCount(xxlJobLogReport.getSucCount());
+        data.setFailCount(xxlJobLogReport.getFailCount());
+
+        entityManager.merge(data);
+        return 1;
+    }
+
+    @Override
+    public List<XxlJobLogReport> queryLogReport(Date triggerDayFrom, Date triggerDayTo) {
+        return xxlJobLogReportRepository.queryXxlJobLogReportsByTriggerDayBetweenOrderByTriggerDayAsc(triggerDayFrom,triggerDayTo);
+    }
+
+    @Override
+    public XxlJobLogReport queryLogReportTotal() {
+        CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Tuple> criteriaQuery = criteriaBuilder.createTupleQuery();
+        Root<XxlJobLogReport> root = criteriaQuery.from(XxlJobLogReport.class);
+        criteriaQuery.multiselect(
+                criteriaBuilder.sum(root.get("runningCount")).alias("runningCount"),
+                criteriaBuilder.sum(root.get("sucCount")).alias("sucCount"),
+                criteriaBuilder.sum(root.get("failCount")).alias("failCount")
+        );
+
+        Tuple result = entityManager.createQuery(criteriaQuery).getSingleResult();
+
+        XxlJobLogReport xxlJobLogReport = new XxlJobLogReport();
+        xxlJobLogReport.setFailCount(((Long)result.get(2)).intValue());
+        xxlJobLogReport.setSucCount(((Long)result.get(1)).intValue());
+        xxlJobLogReport.setRunningCount(((Long)result.get(0)).intValue());
+
+        return xxlJobLogReport;
+    }
+
+    @Autowired
+    private XxlJobLogReportRepository xxlJobLogReportRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/impl/XxlJobRegistryDaoImpl.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/impl/XxlJobRegistryDaoImpl.java
@@ -1,0 +1,118 @@
+package com.xxl.job.admin.dao.impl;
+
+import com.xxl.job.admin.core.model.XxlJobRegistry;
+import com.xxl.job.admin.dao.XxlJobRegistryDao;
+import com.xxl.job.admin.repository.XxlJobRegistryRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.criteria.*;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * @author YunSongLiu
+ */
+@Service
+public class XxlJobRegistryDaoImpl implements XxlJobRegistryDao {
+
+    @Override
+    public List<Integer> findDead(int timeout, Date nowTime) {
+        CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Integer> criteriaQuery = criteriaBuilder.createQuery(Integer.class);
+        Root<XxlJobRegistry> root = criteriaQuery.from(XxlJobRegistry.class);
+        Predicate predicate = criteriaBuilder.lessThan(root.get("updateTime"),minusDate(nowTime,timeout));
+        criteriaQuery.select(root.get("id")).where(predicate);
+
+        return entityManager.createQuery(criteriaQuery).getResultList();
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public int removeDead(List<Integer> ids) {
+        CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
+        CriteriaDelete<XxlJobRegistry> criteriaDelete = criteriaBuilder.createCriteriaDelete(XxlJobRegistry.class);
+        Root<XxlJobRegistry> root = criteriaDelete.from(XxlJobRegistry.class);
+
+        CriteriaBuilder.In<Object> in = criteriaBuilder.in(root.get("id"));
+        in.value(ids);
+
+        criteriaDelete.where(in);
+
+        entityManager.createQuery(criteriaDelete).executeUpdate();
+
+        return 1;
+    }
+
+    @Override
+    public List<XxlJobRegistry> findAll(int timeout, Date nowTime) {
+        CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
+        CriteriaQuery<XxlJobRegistry> criteriaQuery = criteriaBuilder.createQuery(XxlJobRegistry.class);
+        Root<XxlJobRegistry> root = criteriaQuery.from(XxlJobRegistry.class);
+        Predicate predicate = criteriaBuilder.greaterThan(root.get("updateTime"),minusDate(nowTime,timeout));
+        criteriaQuery.where(predicate);
+
+        return entityManager.createQuery(criteriaQuery).getResultList();
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public int registryUpdate(String registryGroup, String registryKey, String registryValue, Date updateTime) {
+        XxlJobRegistry xxlJobRegistry = xxlJobRegistryRepository.findByRegistryGroupEqualsAndRegistryValueEqualsAndRegistryKeyEquals(registryGroup,registryValue,registryKey);
+        if (xxlJobRegistry == null) {
+            return 0;
+        }
+        xxlJobRegistry.setUpdateTime(updateTime);
+        entityManager.persist(xxlJobRegistry);
+        entityManager.flush();
+        return 1;
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public int registrySave(String registryGroup, String registryKey, String registryValue, Date updateTime) {
+        XxlJobRegistry xxlJobRegistry = new XxlJobRegistry();
+        xxlJobRegistry.setRegistryGroup(registryGroup);
+        xxlJobRegistry.setRegistryKey(registryKey);
+        xxlJobRegistry.setRegistryValue(registryValue);
+        xxlJobRegistry.setUpdateTime(updateTime);
+        entityManager.persist(xxlJobRegistry);
+        return 1;
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public int registryDelete(String registryGroup, String registryKey, String registryValue) {
+        CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
+        CriteriaDelete<XxlJobRegistry> criteriaDelete = criteriaBuilder.createCriteriaDelete(XxlJobRegistry.class);
+        Root<XxlJobRegistry> root = criteriaDelete.from(XxlJobRegistry.class);
+
+        Predicate predicate = criteriaBuilder.conjunction();
+
+        predicate.getExpressions().add(criteriaBuilder.equal(root.get("registryGroup"),registryGroup));
+        predicate.getExpressions().add(criteriaBuilder.equal(root.get("registryKey"),registryKey));
+        predicate.getExpressions().add(criteriaBuilder.equal(root.get("registryValue"),registryValue));
+
+        criteriaDelete.where(predicate);
+
+        entityManager.createQuery(criteriaDelete).executeUpdate();
+        return 0;
+    }
+
+    private Date minusDate(Date date, int seconds) {
+        Instant instant = date.toInstant();
+        ZoneId zoneId = ZoneId.systemDefault();
+        return Date.from(instant.atZone(zoneId).toLocalDateTime().minusSeconds(seconds).atZone(zoneId).toInstant());
+    }
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private XxlJobRegistryRepository xxlJobRegistryRepository;
+
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/impl/XxlJobUserDaoImpl.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/impl/XxlJobUserDaoImpl.java
@@ -1,0 +1,92 @@
+package com.xxl.job.admin.dao.impl;
+
+import com.xxl.job.admin.core.model.XxlJobUser;
+import com.xxl.job.admin.dao.XxlJobUserDao;
+import com.xxl.job.admin.repository.XxlJobUserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import javax.persistence.EntityManager;
+import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.Predicate;
+import java.util.List;
+
+/**
+ * @author YunSongLiu
+ */
+@Service
+public class XxlJobUserDaoImpl implements XxlJobUserDao {
+
+    @Override
+    public Page<XxlJobUser> pageList(int offset, int pagesize, String username, int role) {
+        Pageable pageable = PageRequest.of(offset / pagesize, pagesize, Sort.Direction.DESC, "id");
+        Specification<XxlJobUser> specification = (Specification<XxlJobUser>) (root, criteriaQuery, criteriaBuilder) -> {
+            Predicate predicate = criteriaBuilder.conjunction();
+            List<Expression<Boolean>> expressions = predicate.getExpressions();
+            if (!StringUtils.isEmpty(username)) {
+                expressions.add(criteriaBuilder.like(root.get("username"), "%" + username + "%"));
+            }
+            if (role > -1) {
+                expressions.add(criteriaBuilder.equal(root.get("role"), role));
+            }
+            return predicate;
+        };
+
+        return xxlJobUserRepository.findAll(specification, pageable);
+    }
+
+    @Override
+    public int pageListCount(int offset, int pagesize, String username, int role) {
+        return 0;
+    }
+
+    @Override
+    public XxlJobUser loadByUserName(String username) {
+        return xxlJobUserRepository.findByUsernameEquals(username);
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public int save(XxlJobUser xxlJobUser) {
+        entityManager.persist(xxlJobUser);
+        entityManager.flush();
+        return 1;
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public int update(XxlJobUser xxlJobUser) {
+        XxlJobUser data = xxlJobUserRepository.findById(xxlJobUser.getId()).orElse(null);
+        if (data == null) {
+            return 0;
+        }
+
+        if (!StringUtils.isEmpty(xxlJobUser.getPassword())){
+            data.setPassword(xxlJobUser.getPassword());
+        }
+        data.setRole(xxlJobUser.getRole());
+        data.setPermission(xxlJobUser.getPermission());
+        entityManager.merge(data);
+        entityManager.flush();
+        return 1;
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public int delete(int id) {
+        xxlJobUserRepository.deleteById(id);
+        return 1;
+    }
+
+    @Autowired
+    private XxlJobUserRepository xxlJobUserRepository;
+    @Autowired
+    private EntityManager entityManager;
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/repository/XxlJobGroupRepository.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/repository/XxlJobGroupRepository.java
@@ -1,0 +1,18 @@
+package com.xxl.job.admin.repository;
+
+import com.xxl.job.admin.core.model.XxlJobGroup;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+import java.util.List;
+
+/**
+ * @author YunSongLiu
+ */
+public interface XxlJobGroupRepository extends JpaRepository<XxlJobGroup, Integer>, JpaSpecificationExecutor<XxlJobGroup> {
+
+    List<XxlJobGroup> queryXxlJobGroupsByAddressTypeEqualsOrderByIdAsc(int addressType);
+
+    XxlJobGroup queryXxlJobGroupByIdEquals(int id);
+
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/repository/XxlJobGroupRepository.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/repository/XxlJobGroupRepository.java
@@ -1,6 +1,7 @@
 package com.xxl.job.admin.repository;
 
 import com.xxl.job.admin.core.model.XxlJobGroup;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
@@ -11,7 +12,7 @@ import java.util.List;
  */
 public interface XxlJobGroupRepository extends JpaRepository<XxlJobGroup, Integer>, JpaSpecificationExecutor<XxlJobGroup> {
 
-    List<XxlJobGroup> queryXxlJobGroupsByAddressTypeEqualsOrderByIdAsc(int addressType);
+    List<XxlJobGroup> queryXxlJobGroupsByAddressTypeEquals(int addressType, Sort sort);
 
     XxlJobGroup queryXxlJobGroupByIdEquals(int id);
 

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/repository/XxlJobInfoRepository.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/repository/XxlJobInfoRepository.java
@@ -1,0 +1,21 @@
+package com.xxl.job.admin.repository;
+
+import com.xxl.job.admin.core.model.XxlJobInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+/**
+ * @author YunSongLiu
+ */
+public interface XxlJobInfoRepository extends JpaRepository<XxlJobInfo, Integer>, JpaSpecificationExecutor<XxlJobInfo> {
+
+    List<XxlJobInfo> queryXxlJobInfosByJobGroupEquals(int jobGroup);
+
+    @Modifying
+    @Query("update XxlJobInfo set triggerLastTime = ?2 , triggerNextTime = ?3,triggerStatus = ?4 where id = ?1")
+    void updateSchedule(int id, long triggerLastTime, long triggerNextTime, int triggerStatus);
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/repository/XxlJobInfoRepository.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/repository/XxlJobInfoRepository.java
@@ -3,8 +3,6 @@ package com.xxl.job.admin.repository;
 import com.xxl.job.admin.core.model.XxlJobInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
@@ -15,7 +13,4 @@ public interface XxlJobInfoRepository extends JpaRepository<XxlJobInfo, Integer>
 
     List<XxlJobInfo> queryXxlJobInfosByJobGroupEquals(int jobGroup);
 
-    @Modifying
-    @Query("update XxlJobInfo set triggerLastTime = ?2 , triggerNextTime = ?3,triggerStatus = ?4 where id = ?1")
-    void updateSchedule(int id, long triggerLastTime, long triggerNextTime, int triggerStatus);
 }

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/repository/XxlJobLogGlueRepository.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/repository/XxlJobLogGlueRepository.java
@@ -1,0 +1,18 @@
+package com.xxl.job.admin.repository;
+
+import com.xxl.job.admin.core.model.XxlJobLogGlue;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+import java.util.List;
+
+/**
+ * @author YunSongLiu
+ */
+public interface XxlJobLogGlueRepository extends JpaRepository<XxlJobLogGlue, Integer>, JpaSpecificationExecutor<XxlJobLogGlue> {
+
+    List<XxlJobLogGlue> findByJobIdEqualsOrderByIdDesc(int jobId);
+
+    void deleteAllByJobIdEquals(int jobId);
+
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/repository/XxlJobLogReportRepository.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/repository/XxlJobLogReportRepository.java
@@ -1,0 +1,17 @@
+package com.xxl.job.admin.repository;
+
+import com.xxl.job.admin.core.model.XxlJobLogReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+import java.util.Date;
+import java.util.List;
+
+/**
+ * @author YunSongLiu
+ */
+public interface XxlJobLogReportRepository extends JpaRepository<XxlJobLogReport, Integer>, JpaSpecificationExecutor<XxlJobLogReport> {
+    List<XxlJobLogReport> queryXxlJobLogReportsByTriggerDayBetweenOrderByTriggerDayAsc(Date from, Date to);
+
+    XxlJobLogReport findByTriggerDayEquals(Date date);
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/repository/XxlJobLogRepository.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/repository/XxlJobLogRepository.java
@@ -1,0 +1,16 @@
+package com.xxl.job.admin.repository;
+
+import com.xxl.job.admin.core.model.XxlJobLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+/**
+ * @author YunSongLiu
+ */
+public interface XxlJobLogRepository   extends JpaRepository<XxlJobLog, Long>, JpaSpecificationExecutor<XxlJobLog> {
+
+    void deleteXxlJobLogsByJobId(int jobId);
+
+    XxlJobLog queryXxlJobLogByIdEqualsAndAlarmStatusEquals(long id,int alarmStatus);
+
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/repository/XxlJobRegistryRepository.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/repository/XxlJobRegistryRepository.java
@@ -1,0 +1,20 @@
+package com.xxl.job.admin.repository;
+
+import com.xxl.job.admin.core.model.XxlJobRegistry;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+import java.util.Date;
+import java.util.List;
+
+/**
+ * @author YunSongLiu
+ */
+
+public interface XxlJobRegistryRepository extends JpaRepository<XxlJobRegistry, Integer>, JpaSpecificationExecutor<XxlJobRegistry> {
+
+    List<XxlJobRegistry> findAllByUpdateTimeGreaterThan(Date dateTime);
+
+    XxlJobRegistry findByRegistryGroupEqualsAndRegistryValueEqualsAndRegistryKeyEquals(String registryGroup,String registryValue, String registryKey);
+
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/repository/XxlJobUserRepository.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/repository/XxlJobUserRepository.java
@@ -1,0 +1,14 @@
+package com.xxl.job.admin.repository;
+
+import com.xxl.job.admin.core.model.XxlJobUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+/**
+ * @author YunSongLiu
+ */
+public interface XxlJobUserRepository extends JpaRepository<XxlJobUser, Integer>, JpaSpecificationExecutor<XxlJobUser> {
+
+    XxlJobUser findByUsernameEquals(String username);
+
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/service/impl/XxlJobServiceImpl.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/service/impl/XxlJobServiceImpl.java
@@ -1,8 +1,8 @@
 package com.xxl.job.admin.service.impl;
 
+import com.xxl.job.admin.core.cron.CronExpression;
 import com.xxl.job.admin.core.model.XxlJobGroup;
 import com.xxl.job.admin.core.model.XxlJobInfo;
-import com.xxl.job.admin.core.cron.CronExpression;
 import com.xxl.job.admin.core.model.XxlJobLogReport;
 import com.xxl.job.admin.core.route.ExecutorRouteStrategyEnum;
 import com.xxl.job.admin.core.thread.JobScheduleHelper;
@@ -15,6 +15,7 @@ import com.xxl.job.core.glue.GlueTypeEnum;
 import com.xxl.job.core.util.DateUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.Resource;
@@ -44,9 +45,10 @@ public class XxlJobServiceImpl implements XxlJobService {
 	@Override
 	public Map<String, Object> pageList(int start, int length, int jobGroup, int triggerStatus, String jobDesc, String executorHandler, String author) {
 
+		Page<XxlJobInfo> page = xxlJobInfoDao.pageList(start, length, jobGroup, triggerStatus, jobDesc, executorHandler, author);
 		// page list
-		List<XxlJobInfo> list = xxlJobInfoDao.pageList(start, length, jobGroup, triggerStatus, jobDesc, executorHandler, author);
-		int list_count = xxlJobInfoDao.pageListCount(start, length, jobGroup, triggerStatus, jobDesc, executorHandler, author);
+		List<XxlJobInfo> list = page.getContent();
+		int list_count = (int) page.getTotalElements();
 		
 		// package result
 		Map<String, Object> maps = new HashMap<String, Object>();

--- a/xxl-job-admin/src/main/resources/application.properties
+++ b/xxl-job-admin/src/main/resources/application.properties
@@ -2,6 +2,11 @@
 server.port=8080
 server.servlet.context-path=/xxl-job-admin
 
+#spring.jpa.properties.hibernate.dialect=com.xxl.job.admin.core.conf.MysqlConfig
+spring.jpa.hibernate.naming.physical-strategy=com.xxl.job.admin.core.conf.TableNameStrategy
+
+spring.jpa.generate-ddl=true
+
 ### actuator
 management.server.servlet.context-path=/actuator
 management.health.mail.enabled=false

--- a/xxl-job-admin/src/main/resources/application.properties
+++ b/xxl-job-admin/src/main/resources/application.properties
@@ -19,7 +19,7 @@ spring.freemarker.request-context-attribute=request
 spring.freemarker.settings.number_format=0.##########
 
 ### mybatis
-mybatis.mapper-locations=classpath:/mybatis-mapper/*Mapper.xml
+#mybatis.mapper-locations=classpath:/mybatis-mapper/*Mapper.xml
 #mybatis.type-aliases-package=com.xxl.job.admin.core.model
 
 ### xxl-job, datasource

--- a/xxl-job-admin/src/main/resources/application.properties
+++ b/xxl-job-admin/src/main/resources/application.properties
@@ -32,6 +32,7 @@ spring.datasource.url=jdbc:mysql://127.0.0.1:3306/xxl_job?useUnicode=true&charac
 spring.datasource.username=root
 spring.datasource.password=root_pwd
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.properties.hibernate.dialect=com.xxl.job.admin.core.conf.MysqlConfig
 
 ### datasource-pool
 spring.datasource.type=com.zaxxer.hikari.HikariDataSource

--- a/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobGroupMapper.xml
+++ b/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobGroupMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 	"http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="com.xxl.job.admin.dao.XxlJobGroupDao">
+<mapper namespace="">
 	
 	<resultMap id="XxlJobGroup" type="com.xxl.job.admin.core.model.XxlJobGroup" >
 		<result column="id" property="id" />

--- a/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobInfoMapper.xml
+++ b/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobInfoMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 	"http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="com.xxl.job.admin.dao.XxlJobInfoDao">
+<mapper namespace="">
 
 	<resultMap id="XxlJobInfo" type="com.xxl.job.admin.core.model.XxlJobInfo" >
 		<result column="id" property="id" />

--- a/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobLogGlueMapper.xml
+++ b/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobLogGlueMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 	"http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="com.xxl.job.admin.dao.XxlJobLogGlueDao">
+<mapper namespace="">
 	
 	<resultMap id="XxlJobLogGlue" type="com.xxl.job.admin.core.model.XxlJobLogGlue" >
 		<result column="id" property="id" />

--- a/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobLogMapper.xml
+++ b/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobLogMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 	"http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="com.xxl.job.admin.dao.XxlJobLogDao">
+<mapper namespace="">
 	
 	<resultMap id="XxlJobLog" type="com.xxl.job.admin.core.model.XxlJobLog" >
 		<result column="id" property="id" />

--- a/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobLogReportMapper.xml
+++ b/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobLogReportMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 	"http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="com.xxl.job.admin.dao.XxlJobLogReportDao">
+<mapper namespace="">
 	
 	<resultMap id="XxlJobLogReport" type="com.xxl.job.admin.core.model.XxlJobLogReport" >
 		<result column="id" property="id" />

--- a/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobRegistryMapper.xml
+++ b/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobRegistryMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 	"http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="com.xxl.job.admin.dao.XxlJobRegistryDao">
+<mapper namespace="">
 	
 	<resultMap id="XxlJobRegistry" type="com.xxl.job.admin.core.model.XxlJobRegistry" >
 		<result column="id" property="id" />

--- a/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobUserMapper.xml
+++ b/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobUserMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 	"http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="com.xxl.job.admin.dao.XxlJobUserDao">
+<mapper namespace="">
 
 	<resultMap id="XxlJobUser" type="com.xxl.job.admin.core.model.XxlJobUser" >
 		<result column="id" property="id" />

--- a/xxl-job-admin/src/test/java/com/xxl/job/admin/dao/XxlJobInfoDaoTest.java
+++ b/xxl-job-admin/src/test/java/com/xxl/job/admin/dao/XxlJobInfoDaoTest.java
@@ -4,6 +4,7 @@ import com.xxl.job.admin.core.model.XxlJobInfo;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import javax.annotation.Resource;
@@ -19,8 +20,9 @@ public class XxlJobInfoDaoTest {
 	
 	@Test
 	public void pageList(){
-		List<XxlJobInfo> list = xxlJobInfoDao.pageList(0, 20, 0, -1, null, null, null);
-		int list_count = xxlJobInfoDao.pageListCount(0, 20, 0, -1, null, null, null);
+		Page<XxlJobInfo> page = xxlJobInfoDao.pageList(0, 20, 0, -1, null, null, null);
+		List<XxlJobInfo> list = page.getContent();
+		int list_count = (int) page.getTotalElements();
 		
 		System.out.println(list);
 		System.out.println(list_count);

--- a/xxl-job-admin/src/test/java/com/xxl/job/admin/dao/XxlJobLogDaoTest.java
+++ b/xxl-job-admin/src/test/java/com/xxl/job/admin/dao/XxlJobLogDaoTest.java
@@ -4,6 +4,7 @@ import com.xxl.job.admin.core.model.XxlJobLog;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import javax.annotation.Resource;
@@ -19,8 +20,10 @@ public class XxlJobLogDaoTest {
 
     @Test
     public void test(){
-        List<XxlJobLog> list = xxlJobLogDao.pageList(0, 10, 1, 1, null, null, 1);
-        int list_count = xxlJobLogDao.pageListCount(0, 10, 1, 1, null, null, 1);
+
+        Page<XxlJobLog> page = xxlJobLogDao.pageList(0, 10, 1, 1, null, null, 1);
+        List<XxlJobLog> list = page.getContent();
+        int list_count = (int) page.getTotalElements();
 
         XxlJobLog log = new XxlJobLog();
         log.setJobGroup(1);

--- a/xxl-job-executor-samples/xxl-job-executor-sample-springboot/src/main/java/com/xxl/job/executor/service/jobhandler/SampleXxlJob.java
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-springboot/src/main/java/com/xxl/job/executor/service/jobhandler/SampleXxlJob.java
@@ -42,6 +42,7 @@ public class SampleXxlJob {
 
         for (int i = 0; i < 5; i++) {
             XxlJobLogger.log("beat at:" + i);
+            logger.info("beat at:" + i);
             TimeUnit.SECONDS.sleep(2);
         }
         return ReturnT.SUCCESS;

--- a/xxl-job-executor-samples/xxl-job-executor-sample-springboot/src/main/resources/application.properties
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-springboot/src/main/resources/application.properties
@@ -8,7 +8,7 @@ logging.config=classpath:logback.xml
 
 
 ### xxl-job admin address list, such as "http://address" or "http://address01,http://address02"
-xxl.job.admin.addresses=http://127.0.0.1:8080/xxl-job-admin
+xxl.job.admin.addresses=http://10.32.31.28:8080/xxl-job-admin
 
 ### xxl-job, access token
 xxl.job.accessToken=


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**
1. 将所有的sql语句翻译为了jpa代码语句，并将所有Model实体类加上了jpa的注解，基本上只对dao层进行了修改，除了获取分页信息代码以外没有对上层逻辑代码进行修改，以做到最小改动，但同时可能会对性能有部分影响，大部分的update的操作都是将待修改的数据从数据库中先取出后再进行修改。

2. 为了使用Jpa将所有xml中的namespace置为了空，并将mybatis.mapper-locations=classpath:/mybatis-mapper/*Mapper.xml配置项注释掉了

3. 因为使用了jpa后，所有的分页数据及分页的信息（总页数，总行数...）都可以通过一个方法获取，所以代码中获取分页数据的dao层接口返回类型改为了 Page<> ，其它使用到这个接口的地方改为了
```
Page<> page = dao.pageList();
List<> list = page.getContent;
int list_count = (int) page.getTotalElements();
```

4. 将所有model的主键生成策略改为了通过数据库表（xxl_primary_key_gen）生成，为了能兼容更多的数据库

5. 可以自定义表名前缀，通过重载 SpringPhysicalNamingStrategy 类的 toPhysicalTableName 方法实现，实现类为TableNameStrategy。配置项为xxl.tablename.prefix ,默认值为xxl，对原有的初始化脚本默认情况下不造成影响。包括获取表锁的地方也做了可变前缀处理。

6. 因为新增了jpa，所以可以通过spring.jpa.generate-ddl=true 配置项自动生成所有的数据库表，带上默认的数据库前缀xxl_.。同时为了可以做到自动生成xxl_job_lock这张表，加入了相应的Model实体类。

7. 为了使自动生成的mysql表的编码正常所以新增了MysqlConfig，使得自动生成表的时候能自动设置为utf-8编码

**Other information:**
自测了下没什么问题，之后在项目会在项目中进行测试。如果有bug也会进行更新。