### PR TITLE
safari浏览器显示Invalid Date问题

### DIFF
--- a/xxl-job-admin/src/main/resources/static/js/joblog.index.1.js
+++ b/xxl-job-admin/src/main/resources/static/js/joblog.index.1.js
@@ -116,7 +116,7 @@ $(function() {
 						"data": 'triggerTime',
                         "width":'20%',
 						"render": function ( data, type, row ) {
-							return data?moment(new Date(data)).format("YYYY-MM-DD HH:mm:ss"):"";
+							return data?moment(data).format("YYYY-MM-DD HH:mm:ss"):"";
 						}
 					},
 					{
@@ -145,7 +145,7 @@ $(function() {
 	                	"data": 'handleTime',
                         "width":'20%',
 	                	"render": function ( data, type, row ) {
-	                		return data?moment(new Date(data)).format("YYYY-MM-DD HH:mm:ss"):"";
+	                		return data?moment(data).format("YYYY-MM-DD HH:mm:ss"):"";
 	                	}
 	                },
 	                {


### PR DESCRIPTION
safari浏览器查看调度日志时，调度时间和执行时间显示的都是Invalid Date