### PR TITLE
fixed issues： xxl_job_log_report表重复插入问题 #1650

### DIFF
--- a/doc/db/tables_xxl_job.sql
+++ b/doc/db/tables_xxl_job.sql
@@ -60,6 +60,8 @@ CREATE TABLE `xxl_job_log_report` (
   `running_count` int(11) NOT NULL DEFAULT '0' COMMENT '运行中-日志数量',
   `suc_count` int(11) NOT NULL DEFAULT '0' COMMENT '执行成功-日志数量',
   `fail_count` int(11) NOT NULL DEFAULT '0' COMMENT '执行失败-日志数量',
+  `add_time` datetime DEFAULT NULL,
+  `update_time` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `i_trigger_day` (`trigger_day`) USING BTREE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobLogReportMapper.xml
+++ b/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobLogReportMapper.xml
@@ -24,12 +24,16 @@
 			`trigger_day`,
 			`running_count`,
 			`suc_count`,
-			`fail_count`
+			`fail_count`,
+		    `add_time`,
+		  	`update_time`
 		) VALUES (
 			#{triggerDay},
 			#{runningCount},
 			#{sucCount},
-			#{failCount}
+			#{failCount},
+		    now(),
+		    now()
 		);
 		<!--<selectKey resultType="java.lang.Integer" order="AFTER" keyProperty="id">
 			SELECT LAST_INSERT_ID() 
@@ -40,7 +44,8 @@
         UPDATE xxl_job_log_report
         SET `running_count` = #{runningCount},
         	`suc_count` = #{sucCount},
-        	`fail_count` = #{failCount}
+        	`fail_count` = #{failCount},
+            `update_time` = now()
         WHERE `trigger_day` = #{triggerDay}
     </update>
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**

 xxl_job_log_report表重复插入问题

**Other information:**

Expected behavior：
对于xxl_job_log_report有记录时，不需要调用 XxlJobAdminConfig.getAdminConfig().getXxlJobLogReportDao().save(xxlJobLogReport);

Actual behavior：
对于xxl_job_log_report有记录时，调用 XxlJobAdminConfig.getAdminConfig().getXxlJobLogReportDao().save(xxlJobLogReport);

日志：
org.springframework.dao.DuplicateKeyException: ### Error updating database. Cause: java.sql.SQLIntegrityConstraintViolationException: (conn=6419) Duplicate entry '2020-05-05 00:00:00' for key 'i_trigger_day'### The error may involve com.xxl.job.admin.dao.XxlJobLogReportDao.save-Inline### The error occurred while setting parameters### SQL: INSERT INTO xxl_job_log_report ( trigger_day, running_count, suc_count, fail_count ) VALUES ( ?, ?, ?, ? );### Cause: java.sql.SQLIntegrityConstraintViolationException: (conn=6419) Duplicate entry '2020-05-05 00:00:00' for key 'i_trigger_day'; (conn=6419) Duplicate entry '2020-05-05 00:00:00' for key 'i_trigger_day'; nested exception is java.sql.SQLIntegrityConstraintViolationException: (conn=6419) Duplicate entry '2020-05-05 00:00:00' for key 'i_trigger_day'at org.springframework.jdbc.support.SQLErrorCodeSQLExceptionTranslator.doTranslate(SQLErrorCodeSQLExceptionTranslator.java:243)at org.springframework.jdbc.support.AbstractFallbackSQLExceptionTranslator.translate(AbstractFallbackSQLExceptionTranslator.java:72)at org.mybatis.spring.MyBatisExceptionTranslator.translateExceptionIfPossible(MyBatisExceptionTranslator.java:73)at org.mybatis.spring.SqlSessionTemplate$SqlSessionInterceptor.invoke(SqlSessionTemplate.java:446)at com.sun.proxy.$Proxy92.insert(Unknown Source)at org.mybatis.spring.SqlSessionTemplate.insert(SqlSessionTemplate.java:278)at org.apache.ibatis.binding.MapperMethod.execute(MapperMethod.java:58)at org.apache.ibatis.binding.MapperProxy.invoke(MapperProxy.java:59)at com.sun.proxy.$Proxy107.save(Unknown Source)at com.xxl.job.admin.core.thread.JobLogReportHelper$1.run(JobLogReportHelper.java:86)at java.lang.Thread.run(Thread.java:748)Caused by: java.sql.SQLIntegrityConstraintViolationException: (conn=6419) Duplicate entry '2020-05-05 00:00:00' for key 'i_trigger_day'at org.mariadb.jdbc.internal.util.exceptions.ExceptionFactory.createException(ExceptionFactory.java:70)at org.mariadb.jdbc.internal.util.exceptions.ExceptionFactory.create(ExceptionFactory.java:153)at org.mariadb.jdbc.MariaDbStatement.executeExceptionEpilogue(MariaDbStatement.java:273)at org.mariadb.jdbc.ClientSidePreparedStatement.executeInternal(ClientSidePreparedStatement.java:229)at org.mariadb.jdbc.ClientSidePreparedStatement.execute(ClientSidePreparedStatement.java:149)at com.alibaba.druid.filter.FilterChainImpl.preparedStatement_execute(FilterChainImpl.java:3461)at com.alibaba.druid.filter.FilterEventAdapter.preparedStatement_execute(FilterEventAdapter.java:440)at com.alibaba.druid.filter.FilterChainImpl.preparedStatement_execute(FilterChainImpl.java:3459)at com.alibaba.druid.wall.WallFilter.preparedStatement_execute(WallFilter.java:627)at com.alibaba.druid.filter.FilterChainImpl.preparedStatement_execute(FilterChainImpl.java:3459)at com.alibaba.druid.filter.FilterEventAdapter.preparedStatement_execute(FilterEventAdapter.java:440)at com.alibaba.druid.filter.FilterChainImpl.preparedStatement_execute(FilterChainImpl.java:3459)at com.alibaba.druid.proxy.jdbc.PreparedStatementProxyImpl.execute(PreparedStatementProxyImpl.java:167)at com.alibaba.druid.pool.DruidPooledPreparedStatement.execute(DruidPooledPreparedStatement.java:497)at org.apache.ibatis.executor.statement.PreparedStatementHandler.update(PreparedStatementHandler.java:46)at org.apache.ibatis.executor.statement.RoutingStatementHandler.update(RoutingStatementHandler.java:74)at org.apache.ibatis.executor.SimpleExecutor.doUpdate(SimpleExecutor.java:50)at org.apache.ibatis.executor.BaseExecutor.update(BaseExecutor.java:117)at org.apache.ibatis.executor.CachingExecutor.update(CachingExecutor.java:76)at org.apache.ibatis.session.defaults.DefaultSqlSession.update(DefaultSqlSession.java:198)at org.apache.ibatis.session.defaults.DefaultSqlSession.insert(DefaultSqlSession.java:185)at sun.reflect.GeneratedMethodAccessor70.invoke(Unknown Source)at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)at java.lang.reflect.Method.invoke(Method.java:498)at org.mybatis.spring.SqlSessionTemplate$SqlSessionInterceptor.invoke(SqlSessionTemplate.java:433)... 7 moreCaused by: org.mariadb.jdbc.internal.util.exceptions.MariaDbSqlException: Duplicate entry '2020-05-05 00:00:00' for key 'i_trigger_day'at org.mariadb.jdbc.internal.util.exceptions.MariaDbSqlException.of(MariaDbSqlException.java:34)at org.mariadb.jdbc.internal.protocol.AbstractQueryProtocol.exceptionWithQuery(AbstractQueryProtocol.java:194)at org.mariadb.jdbc.internal.protocol.AbstractQueryProtocol.exceptionWithQuery(AbstractQueryProtocol.java:177)at org.mariadb.jdbc.internal.protocol.AbstractQueryProtocol.executeQuery(AbstractQueryProtocol.java:321)at org.mariadb.jdbc.ClientSidePreparedStatement.executeInternal(ClientSidePreparedStatement.java:220)... 28 moreCaused by: java.sql.SQLException: Duplicate entry '2020-05-05 00:00:00' for key 'i_trigger_day'at org.mariadb.jdbc.internal.protocol.AbstractQueryProtocol.readErrorPacket(AbstractQueryProtocol.java:1674)at org.mariadb.jdbc.internal.protocol.AbstractQueryProtocol.readPacket(AbstractQueryProtocol.java:1536)at org.mariadb.jdbc.internal.protocol.AbstractQueryProtocol.getResult(AbstractQueryProtocol.java:1499)at org.mariadb.jdbc.internal.protocol.AbstractQueryProtocol.executeQuery(AbstractQueryProtocol.java:318)
