### PR TITLE
replace <br> with \n 以便在前端可以展示日志中的 '<' 标签

### DIFF
--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/controller/JobLogController.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/controller/JobLogController.java
@@ -141,6 +141,11 @@ public class JobLogController {
 			ExecutorBiz executorBiz = XxlJobScheduler.getExecutorBiz(executorAddress);
 			ReturnT<LogResult> logResult = executorBiz.log(new LogParam(triggerTime, logId, fromLineNum));
 
+			if (logResult.getContent()!=null && logResult.getContent().getLogContent()!=null) {
+				String logContent = logResult.getContent().getLogContent();
+				logResult.getContent().setLogContent(logContent.replaceAll("<", "&lt;"));
+			}
+
 			// is end
             if (logResult.getContent()!=null && logResult.getContent().getFromLineNum() > logResult.getContent().getToLineNum()) {
                 XxlJobLog jobLog = xxlJobLogDao.load(logId);

--- a/xxl-job-core/src/main/java/com/xxl/job/core/thread/JobThread.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/thread/JobThread.java
@@ -121,7 +121,7 @@ public class JobThread extends Thread{
 					ShardingUtil.setShardingVo(new ShardingUtil.ShardingVO(triggerParam.getBroadcastIndex(), triggerParam.getBroadcastTotal()));
 
 					// execute
-					XxlJobLogger.log("<br>----------- xxl-job job execute start -----------<br>----------- Param:" + triggerParam.getExecutorParams());
+					XxlJobLogger.log("\n----------- xxl-job job execute start -----------\n----------- Param:" + triggerParam.getExecutorParams());
 
 					if (triggerParam.getExecutorTimeout() > 0) {
 						// limit timeout
@@ -140,7 +140,7 @@ public class JobThread extends Thread{
 							executeResult = futureTask.get(triggerParam.getExecutorTimeout(), TimeUnit.SECONDS);
 						} catch (TimeoutException e) {
 
-							XxlJobLogger.log("<br>----------- xxl-job job execute timeout");
+							XxlJobLogger.log("\n----------- xxl-job job execute timeout");
 							XxlJobLogger.log(e);
 
 							executeResult = new ReturnT<String>(IJobHandler.FAIL_TIMEOUT.getCode(), "job execute timeout ");
@@ -161,7 +161,7 @@ public class JobThread extends Thread{
 										:executeResult.getMsg());
 						executeResult.setContent(null);	// limit obj size
 					}
-					XxlJobLogger.log("<br>----------- xxl-job job execute end(finish) -----------<br>----------- ReturnT:" + executeResult);
+					XxlJobLogger.log("\n----------- xxl-job job execute end(finish) -----------\n----------- ReturnT:" + executeResult);
 
 				} else {
 					if (idleTimes > 30) {
@@ -172,7 +172,7 @@ public class JobThread extends Thread{
 				}
 			} catch (Throwable e) {
 				if (toStop) {
-					XxlJobLogger.log("<br>----------- JobThread toStop, stopReason:" + stopReason);
+					XxlJobLogger.log("\n----------- JobThread toStop, stopReason:" + stopReason);
 				}
 
 				StringWriter stringWriter = new StringWriter();
@@ -180,7 +180,7 @@ public class JobThread extends Thread{
 				String errorMsg = stringWriter.toString();
 				executeResult = new ReturnT<String>(ReturnT.FAIL_CODE, errorMsg);
 
-				XxlJobLogger.log("<br>----------- JobThread Exception:" + errorMsg + "<br>----------- xxl-job job execute end(error) -----------");
+				XxlJobLogger.log("\n----------- JobThread Exception:" + errorMsg + "\n----------- xxl-job job execute end(error) -----------");
 			} finally {
                 if(triggerParam != null) {
                     // callback handler info


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**

主要代码是 `logContent.replaceAll("<", "&lt;")` 让浏览器可以正常显示日志中的 `<` ；
之前如果日志里面有类似 `<x` 这种，即使在 `<pre>` 标签里面，仍然会被浏览器解析成 html 的标签，见 https://developer.mozilla.org/zh-CN/docs/Web/HTML/Element/pre

**Other information:**