### PR TITLE
fix ExecutorRouteRound count++ concurrency problems, use AtomicIntege…

### DIFF
--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/route/strategy/ExecutorRouteRound.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/route/strategy/ExecutorRouteRound.java
@@ -8,14 +8,16 @@ import java.util.List;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Created by xuxueli on 17/3/10.
  */
 public class ExecutorRouteRound extends ExecutorRouter {
 
-    private static ConcurrentMap<Integer, Integer> routeCountEachJob = new ConcurrentHashMap<Integer, Integer>();
+    private static ConcurrentMap<Integer, AtomicInteger> routeCountEachJob = new ConcurrentHashMap<>();
     private static long CACHE_VALID_TIME = 0;
+
     private static int count(int jobId) {
         // cache clear
         if (System.currentTimeMillis() > CACHE_VALID_TIME) {
@@ -23,11 +25,16 @@ public class ExecutorRouteRound extends ExecutorRouter {
             CACHE_VALID_TIME = System.currentTimeMillis() + 1000*60*60*24;
         }
 
-        // count++
-        Integer count = routeCountEachJob.get(jobId);
-        count = (count==null || count>1000000)?(new Random().nextInt(100)):++count;  // 初始化时主动Random一次，缓解首次压力
+        AtomicInteger count = routeCountEachJob.get(jobId);
+        // 初始化时主动Random一次，缓解首次压力
+        if (count == null || count.get() > 1000000) {
+            count = new AtomicInteger(new Random().nextInt(100));
+        } else {
+            // count++
+            count.addAndGet(1);
+        }
         routeCountEachJob.put(jobId, count);
-        return count;
+        return count.get();
     }
 
     @Override


### PR DESCRIPTION
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**The description of the PR:**

您好，我在阅读xxl-job源码过程貌似发现了一个问题：
分支：master
在 com.xxl.job.admin.core.route.strategy.ExecutorRouteRound.count(int jobId) 轮询路由算法中count++多线程的情况可能会出现并发覆盖的问题，我认为可使用AtomicInteger代替Integer避免count值被覆盖。
望采纳！谢谢

**Other information:**