### PR TITLE
add validation-timeout to fix lost job scheduling bug

### DIFF
--- a/xxl-job-admin/src/main/resources/application.properties
+++ b/xxl-job-admin/src/main/resources/application.properties
@@ -38,6 +38,7 @@ spring.datasource.hikari.pool-name=HikariCP
 spring.datasource.hikari.max-lifetime=900000
 spring.datasource.hikari.connection-timeout=10000
 spring.datasource.hikari.connection-test-query=SELECT 1
+spring.datasource.hikari.validation-timeout=1000
 
 ### xxl-job, email
 spring.mail.host=smtp.qq.com


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:
**The description of the PR:**
       目前最新版本的数据库配置中，配置了获取connection前做连接有效性的校验，但并没有配置select 1校验超时时间，hikari默认超时时间为5s，在小概率的情况下会出现select 1在5s内校验未返回结果的情况，当出现这种问题时，应用获取connection的时间会大于5s，当该问题发生在job调度时，会导致一些job丢失调度。
        在2.1.x版本时，由于job-admin用的是8.x版本的tomcat jdbc连接池，校验超时时间默认是不超时的，导致这个job丢失调度的情况更为明显，在多实例的场景下，一个实例获取了调度的锁，然后从数据库查询需要调度的job，此时需从连接池中获取connection，在获取connection前做select 1校验，当这个校验长时间未返回结果时，应用获取不到connection进而被hang住，另外的实例由于获取不到调度的锁也不能进行job调度，超过锁等待超时时间就会报Lock wait timeout exceeded; try restarting transaction的错误。我在2.1.x版本的job admin中添加校验超时的配置，并未生效，怀疑是8.0版本的tomcat jdbc有问题，后面使用hikari后再配置超时时间即可解决job丢失调度的问题，select 1校验超时后，应用会放弃当前connection，并重新从连接池中获取新的connection。

该错误在社区已有不少人反馈。以下两个都是相关的issue，
https://github.com/xuxueli/xxl-job/issues/1693
https://github.com/xuxueli/xxl-job/issues/1004
由于这个问题出现的概率较低，重现难度较大，我的应用是通过接入skywalking进行链路跟踪后才发现select 1校验超时的。
以下是配了3s校验超时的情况
![image](https://user-images.githubusercontent.com/12760018/89495781-97a9de80-d7eb-11ea-933b-cb4feb56b7ce.png)
下图是job-admin的api请求，当校验connection超时后放弃旧的connection，重新获取新的connection继续sql的查询。当在获取锁后进行job的查询调度时出现校验超时后，也会重新获取新的有效connection进行查询调度，可以避免jod的丢失调度的问题。
![image](https://user-images.githubusercontent.com/12760018/89495870-c9bb4080-d7eb-11ea-9b1e-9ef4f33970cb.png)


**Other information:**