### PR TITLE
解决调度中心的执行日志Console读取远程日志时，由于未指定编码导致中文乱码的问题

### DIFF
--- a/xxl-job-core/src/main/java/com/xxl/job/core/util/XxlJobRemotingUtil.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/util/XxlJobRemotingUtil.java
@@ -118,7 +118,7 @@ public class XxlJobRemotingUtil {
             }
 
             // result
-            bufferedReader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+            bufferedReader = new BufferedReader(new InputStreamReader(connection.getInputStream(), "UTF-8"));
             StringBuilder result = new StringBuilder();
             String line;
             while ((line = bufferedReader.readLine()) != null) {


### PR DESCRIPTION
调度中心查看执行日志的Console读取远程日志时，使用了com.xxl.job.core.util.XxlJobRemotingUtil的postBody方法中，读取远程数据的时候，new BufferedReader(new InputStreamReader(connection.getInputStream()))未指定编码，如果操作系统编码设置不当，会中文乱码。修改为new BufferedReader(new InputStreamReader(connection.getInputStream(), "UTF-8"))

