### PR TITLE
解决容器重新发布 ip 不一致无法查询历史日志 / Fix log report address

### DIFF
--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/controller/JobLogController.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/controller/JobLogController.java
@@ -19,6 +19,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -125,10 +127,21 @@ public class JobLogController {
 		if (jobLog == null) {
             throw new RuntimeException(I18nUtil.getString("joblog_logid_unvalid"));
 		}
+		// find active address
+		XxlJobGroup jobGroup = xxlJobGroupDao.load(jobLog.getJobGroup());
+		String executorAddress = null;
+		String addressList = jobGroup.getAddressList();
+		if (!ObjectUtils.isEmpty(jobGroup) && !StringUtils.isEmpty(addressList)) {
+			String[] address = addressList.split(",");
+			executorAddress = address[0];
+		}
+		if (StringUtils.isEmpty(executorAddress)) {
+			throw new RuntimeException(I18nUtil.getString("joblog_trigger_address_empty"));
+		}
 
         model.addAttribute("triggerCode", jobLog.getTriggerCode());
         model.addAttribute("handleCode", jobLog.getHandleCode());
-        model.addAttribute("executorAddress", jobLog.getExecutorAddress());
+        model.addAttribute("executorAddress", executorAddress);
         model.addAttribute("triggerTime", jobLog.getTriggerTime().getTime());
         model.addAttribute("logId", jobLog.getId());
 		return "joblog/joblog.detail";

--- a/xxl-job-admin/src/main/resources/i18n/message_en.properties
+++ b/xxl-job-admin/src/main/resources/i18n/message_en.properties
@@ -184,6 +184,7 @@ joblog_rolling_log_refresh=Refresh
 joblog_rolling_log_triggerfail=The job trigger fail, can not view the rolling log
 joblog_rolling_log_failoften=The request for the Rolling log is terminated, the number of failed requests exceeds the limit, Reload the log on the refresh page
 joblog_logid_unvalid=Log ID is illegal
+joblog_trigger_address_empty=Trigger Fail：The job active address is empty
 
 ## job group
 jobgroup_name=Executor Manage

--- a/xxl-job-admin/src/main/resources/i18n/message_zh_CN.properties
+++ b/xxl-job-admin/src/main/resources/i18n/message_zh_CN.properties
@@ -184,6 +184,7 @@ joblog_rolling_log_refresh=刷新
 joblog_rolling_log_triggerfail=任务发起调度失败，无法查看执行日志
 joblog_rolling_log_failoften=终止请求Rolling日志,请求失败次数超上限,可刷新页面重新加载日志
 joblog_logid_unvalid=日志ID非法
+joblog_trigger_address_empty=日志查询失败：执行器地址为空
 
 ## job group
 jobgroup_name=执行器管理

--- a/xxl-job-admin/src/main/resources/i18n/message_zh_TC.properties
+++ b/xxl-job-admin/src/main/resources/i18n/message_zh_TC.properties
@@ -184,6 +184,7 @@ joblog_rolling_log_refresh=更新
 joblog_rolling_log_triggerfail=任務發起調度失敗，無法查看執行日誌
 joblog_rolling_log_failoften=終止請求Rolling日誌，請求失敗次數超上限，可刷新頁面重新加載日誌
 joblog_logid_unvalid=日誌ID非法
+joblog_trigger_address_empty=日誌査詢失敗：執行器地址為空
 
 ## job group
 jobgroup_name=執行器管理


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**

**现象**：

容器重新发布执行器服务后，历史日志无法查看

---

**原因**：

`logDetailPage` 中是查询历史日志，是从数据库中查询对应的历史执行器 ip ，

而重新发布的服务是从 ip 池里获取新的 ip，旧 ip 对应服务已经被销毁了，

重新发布后访问时后台日志还会报  `joblog_logid_unvalid` : `日志ID非法` 错误

---

**处理**：

重新从 `xxl_job_group` 查询最新执行器 ip

**Other information:**

修复相关 is 见：https://github.com/xuxueli/xxl-job/issues/1901