### PR TITLE
Update TriggerCallbackThread.java

### DIFF
--- a/xxl-job-core/src/main/java/com/xxl/job/core/thread/TriggerCallbackThread.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/thread/TriggerCallbackThread.java
@@ -241,6 +241,9 @@ public class TriggerCallbackThread {
         // load and clear file, retry
         for (File callbaclLogFile: callbackLogPath.listFiles()) {
             byte[] callbackParamList_bytes = FileUtil.readFileContent(callbaclLogFile);
+            if(callbackParamList_bytes == null || callbackParamList_bytes.length < 1){
+                continue;
+            }
             List<HandleCallbackParam> callbackParamList = (List<HandleCallbackParam>) JdkSerializeTool.deserialize(callbackParamList_bytes, List.class);
 
             callbaclLogFile.delete();


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [*] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**
遍历callbacklog目录下的文件时，未排除大小为0的文件，从而让callbacklog目录中未处理的文件越来越多，并且xxl-job日志里有大量的readObject异常信息。callbacklog目录中一般是不会有大小为0的文件，遇到这个问题是有一天服务器硬盘被日志塞满了，腾出空间之后仍然发现xxl-job日志里有大量的readObject异常信息，跟踪进去发现callbacklog目录有2个大小为0的文件，回想应该是服务器的硬盘被日志塞满时，xxl-job往callbacklog目录里写文件失败，以至于后面给服务器腾出了空间，并重启了xxl-job，xxl-job日志里依然有readObject异常信息.

**Other information:**