### PR TITLE
修复新版本xxl-job（移除Quartz之后）调度重复执行问题

### DIFF
--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/conf/XxlJobAdminConfig.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/conf/XxlJobAdminConfig.java
@@ -5,9 +5,12 @@ import com.xxl.job.admin.core.scheduler.XxlJobScheduler;
 import com.xxl.job.admin.dao.*;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.TransactionDefinition;
 
 import javax.annotation.Resource;
 import javax.sql.DataSource;
@@ -21,6 +24,26 @@ import java.util.Arrays;
 
 @Component
 public class XxlJobAdminConfig implements InitializingBean, DisposableBean {
+    @Autowired
+    DataSourceTransactionManager dataSourceTransactionManager;
+
+    @Autowired
+    TransactionDefinition transactionDefinition;
+
+    @Resource
+    private XxlJobLockDao xxlJobLockDao;
+
+    public DataSourceTransactionManager getDataSourceTransactionManager() {
+        return dataSourceTransactionManager;
+    }
+
+    public TransactionDefinition getTransactionDefinition() {
+        return transactionDefinition;
+    }
+
+    public XxlJobLockDao getXxlJobLockDao() {
+        return xxlJobLockDao;
+    }
 
     private static XxlJobAdminConfig adminConfig = null;
     public static XxlJobAdminConfig getAdminConfig() {

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/thread/JobScheduleHelper.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/thread/JobScheduleHelper.java
@@ -6,6 +6,9 @@ import com.xxl.job.admin.core.model.XxlJobInfo;
 import com.xxl.job.admin.core.trigger.TriggerTypeEnum;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -52,7 +55,9 @@ public class JobScheduleHelper {
 
                 // pre-read count: treadpool-size * trigger-qps (each trigger cost 50ms, qps = 1000/50 = 20)
                 int preReadCount = (XxlJobAdminConfig.getAdminConfig().getTriggerPoolFastMax() + XxlJobAdminConfig.getAdminConfig().getTriggerPoolSlowMax()) * 20;
-
+                DataSourceTransactionManager transactionManager = XxlJobAdminConfig.getAdminConfig().getDataSourceTransactionManager();
+                TransactionDefinition definition = XxlJobAdminConfig.getAdminConfig().getTransactionDefinition();
+                TransactionStatus transactionStatus = null;
                 while (!scheduleThreadToStop) {
 
                     // Scan Job
@@ -65,12 +70,8 @@ public class JobScheduleHelper {
                     boolean preReadSuc = true;
                     try {
 
-                        conn = XxlJobAdminConfig.getAdminConfig().getDataSource().getConnection();
-                        connAutoCommit = conn.getAutoCommit();
-                        conn.setAutoCommit(false);
-
-                        preparedStatement = conn.prepareStatement(  "select * from xxl_job_lock where lock_name = 'schedule_lock' for update" );
-                        preparedStatement.execute();
+                        transactionStatus = transactionManager.getTransaction(definition);
+                        XxlJobAdminConfig.getAdminConfig().getXxlJobLockDao().lock();
 
                         // tx start
 
@@ -146,40 +147,15 @@ public class JobScheduleHelper {
                             logger.error(">>>>>>>>>>> xxl-job, JobScheduleHelper#scheduleThread error:{}", e);
                         }
                     } finally {
-
-                        // commit
-                        if (conn != null) {
+                        try {
+                            transactionManager.commit(transactionStatus);
+                        }catch (Exception e){
+                            logger.error(e.getMessage(), e);
                             try {
-                                conn.commit();
-                            } catch (SQLException e) {
-                                if (!scheduleThreadToStop) {
-                                    logger.error(e.getMessage(), e);
-                                }
-                            }
-                            try {
-                                conn.setAutoCommit(connAutoCommit);
-                            } catch (SQLException e) {
-                                if (!scheduleThreadToStop) {
-                                    logger.error(e.getMessage(), e);
-                                }
-                            }
-                            try {
-                                conn.close();
-                            } catch (SQLException e) {
-                                if (!scheduleThreadToStop) {
-                                    logger.error(e.getMessage(), e);
-                                }
-                            }
-                        }
-
-                        // close PreparedStatement
-                        if (null != preparedStatement) {
-                            try {
-                                preparedStatement.close();
-                            } catch (SQLException e) {
-                                if (!scheduleThreadToStop) {
-                                    logger.error(e.getMessage(), e);
-                                }
+                                transactionManager.rollback(transactionStatus);
+                            }catch (Exception e1){
+                                logger.error(e.getMessage(), e);
+                                e1.printStackTrace();
                             }
                         }
                     }

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobLockDao.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobLockDao.java
@@ -1,0 +1,8 @@
+package com.xxl.job.admin.dao;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface XxlJobLockDao {
+    public void lock();
+}

--- a/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobLockMapper.xml
+++ b/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobLockMapper.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.xxl.job.admin.dao.XxlJobLockDao">
+
+    <select id="lock" resultType="java.util.HashMap" >
+       select *
+       from xxl_job_lock
+       where lock_name = 'schedule_lock'
+       for update
+    </select>
+
+</mapper>


### PR DESCRIPTION
在mycat读写分离场景下，会出现select xxl_job_info没有读取到最新数据，最终导致获取到旧数据，出现重复执行任务的问题

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**
修复xxl-job 获取任务时 select for update 和 select xxl_job_info不是用的同一个连接问题
在mycat读写分离场景下，会出现select xxl_job_info没有读取到最新数据，最终导致获取到旧数据，出现重复执行任务的问题

**Other information:**