### PR TITLE
'上次调度时间'应该设置为'fromTime'

### DIFF
--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/thread/JobScheduleHelper.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/thread/JobScheduleHelper.java
@@ -281,7 +281,7 @@ public class JobScheduleHelper {
     private void refreshNextValidTime(XxlJobInfo jobInfo, Date fromTime) throws Exception {
         Date nextValidTime = generateNextValidTime(jobInfo, fromTime);
         if (nextValidTime != null) {
-            jobInfo.setTriggerLastTime(jobInfo.getTriggerNextTime());
+            jobInfo.setTriggerLastTime(fromTime.getTime());
             jobInfo.setTriggerNextTime(nextValidTime.getTime());
         } else {
             jobInfo.setTriggerStatus(0);


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**

假设有一个每秒执行一次的任务:

|  TriggerLastTime   | TriggerNextTime  |
|  ----  | ----  |
|  一开始：   |   |
| 2020-11-11 00:00:01  | 2020-11-11 00:00:02 |
| 调度器宕机10分钟后恢复，此时，时间是: 2020-11-11 00:10:01 | |
| 那么再次调度后的字段应该是： | |
| 2020-11-11 00:10:01（而不是2020-11-11 00:00:02）  | 2020-11-11 00:10:02 |
