### PR TITLE
Support for restarting XxlJobExecutor, and exclude loopback & anylocal & linklocal addresses at getLocalAddress()

### DIFF
--- a/xxl-job-core/src/main/java/com/xxl/job/core/executor/XxlJobExecutor.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/executor/XxlJobExecutor.java
@@ -108,6 +108,8 @@ public class XxlJobExecutor  {
         // destory TriggerCallbackThread
         TriggerCallbackThread.getInstance().toStop();
 
+        // clear adminBizList to support restart
+        adminBizList.clear();
     }
 
 

--- a/xxl-job-core/src/main/java/com/xxl/job/core/thread/ExecutorRegistryThread.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/thread/ExecutorRegistryThread.java
@@ -22,7 +22,7 @@ public class ExecutorRegistryThread {
     }
 
     private Thread registryThread;
-    private volatile boolean toStop = false;
+    private volatile boolean toStop;
     public void start(final String appname, final String address){
 
         // valid
@@ -35,6 +35,8 @@ public class ExecutorRegistryThread {
             return;
         }
 
+        toStop = false;
+        
         registryThread = new Thread(new Runnable() {
             @Override
             public void run() {

--- a/xxl-job-core/src/main/java/com/xxl/job/core/thread/JobLogFileCleanThread.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/thread/JobLogFileCleanThread.java
@@ -26,7 +26,7 @@ public class JobLogFileCleanThread {
     }
 
     private Thread localThread;
-    private volatile boolean toStop = false;
+    private volatile boolean toStop;
     public void start(final long logRetentionDays){
 
         // limit min value
@@ -34,6 +34,8 @@ public class JobLogFileCleanThread {
             return;
         }
 
+        toStop = false;
+        
         localThread = new Thread(new Runnable() {
             @Override
             public void run() {

--- a/xxl-job-core/src/main/java/com/xxl/job/core/thread/TriggerCallbackThread.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/thread/TriggerCallbackThread.java
@@ -45,7 +45,7 @@ public class TriggerCallbackThread {
      */
     private Thread triggerCallbackThread;
     private Thread triggerRetryCallbackThread;
-    private volatile boolean toStop = false;
+    private volatile boolean toStop;
     public void start() {
 
         // valid
@@ -54,6 +54,8 @@ public class TriggerCallbackThread {
             return;
         }
 
+        toStop = false;
+        
         // callback
         triggerCallbackThread = new Thread(new Runnable() {
 

--- a/xxl-job-core/src/main/java/com/xxl/job/core/util/IpUtil.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/util/IpUtil.java
@@ -30,6 +30,9 @@ public class IpUtil {
     // ---------------------- valid ----------------------
 
     private static InetAddress toValidAddress(InetAddress address) {
+        if (address == null || address.isLoopbackAddress()) {
+            return null;
+        }
         if (address instanceof Inet6Address) {
             Inet6Address v6Address = (Inet6Address) address;
             if (isPreferIPV6Address()) {
@@ -53,9 +56,6 @@ public class IpUtil {
      * @return
      */
     private static boolean isValidV4Address(InetAddress address) {
-        if (address == null || address.isLoopbackAddress()) {
-            return false;
-        }
         String name = address.getHostAddress();
         boolean result = (name != null
                 && IP_PATTERN.matcher(name).matches()

--- a/xxl-job-core/src/main/java/com/xxl/job/core/util/IpUtil.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/util/IpUtil.java
@@ -30,7 +30,8 @@ public class IpUtil {
     // ---------------------- valid ----------------------
 
     private static InetAddress toValidAddress(InetAddress address) {
-        if (address == null || address.isLoopbackAddress()) {
+        if (address == null || address.isLoopbackAddress()
+            || address.isAnyLocalAddress() || address.isLinkLocalAddress()) {
             return null;
         }
         if (address instanceof Inet6Address) {


### PR DESCRIPTION
What kind of change does this PR introduce? (check at least one)
fix-#2213
fix-#2230

The description of the PR:
// support for restarting xxl-job executor after resetting parameters such as:
xxlJobExecutor.destroy();
xxlJobExecutor.setAdminAddresses(newAddr);
xxlJobExecutor.set....(...);
xxlJobExecutor.start();