### PR TITLE
增加自动注册功能

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
 		<module>xxl-job-core</module>
 		<module>xxl-job-admin</module>
 		<module>xxl-job-executor-samples</module>
+		<module>xxl-job-extension</module>
     </modules>
 
 	<properties>

--- a/xxl-job-admin/pom.xml
+++ b/xxl-job-admin/pom.xml
@@ -1,113 +1,117 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>com.xuxueli</groupId>
-		<artifactId>xxl-job</artifactId>
-		<version>2.2.0</version>
-	</parent>
-	<artifactId>xxl-job-admin</artifactId>
-	<packaging>jar</packaging>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.xuxueli</groupId>
+    <artifactId>xxl-job</artifactId>
+    <version>2.2.0</version>
+  </parent>
+  <artifactId>xxl-job-admin</artifactId>
+  <packaging>jar</packaging>
 
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-starter-parent</artifactId>
-				<version>${spring-boot.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>${spring-boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
-	<dependencies>
+  <dependencies>
 
-		<!-- starter-web：spring-webmvc + autoconfigure + logback + yaml + tomcat -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
-		<!-- starter-test：junit + spring-test + mockito -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
+    <!-- starter-web：spring-webmvc + autoconfigure + logback + yaml + tomcat -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <!-- starter-test：junit + spring-test + mockito -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
 
-		<!-- freemarker-starter -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-freemarker</artifactId>
-		</dependency>
+    <!-- freemarker-starter -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-freemarker</artifactId>
+    </dependency>
 
-		<!-- mail-starter -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-mail</artifactId>
-		</dependency>
+    <!-- mail-starter -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-mail</artifactId>
+    </dependency>
 
-		<!-- starter-actuator -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-actuator</artifactId>
-		</dependency>
+    <!-- starter-actuator -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
 
-		<!-- mybatis-starter：mybatis + mybatis-spring + hikari（default） -->
-		<dependency>
-			<groupId>org.mybatis.spring.boot</groupId>
-			<artifactId>mybatis-spring-boot-starter</artifactId>
-			<version>${mybatis-spring-boot-starter.version}</version>
-		</dependency>
-		<!-- mysql -->
-		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
-			<version>${mysql-connector-java.version}</version>
-		</dependency>
+    <!-- mybatis-starter：mybatis + mybatis-spring + hikari（default） -->
+    <dependency>
+      <groupId>org.mybatis.spring.boot</groupId>
+      <artifactId>mybatis-spring-boot-starter</artifactId>
+      <version>${mybatis-spring-boot-starter.version}</version>
+    </dependency>
+    <!-- mysql -->
+    <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
+      <version>${mysql-connector-java.version}</version>
+    </dependency>
 
-		<!-- xxl-job-core -->
-		<dependency>
-			<groupId>com.xuxueli</groupId>
-			<artifactId>xxl-job-core</artifactId>
-			<version>${project.parent.version}</version>
-		</dependency>
+    <!-- xxl-job-core -->
+    <dependency>
+      <groupId>com.xuxueli</groupId>
+      <artifactId>xxl-job-core</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
 
-	</dependencies>
+  </dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-				<version>${spring-boot.version}</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>repackage</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<!-- docker -->
-			<plugin>
-				<groupId>com.spotify</groupId>
-				<artifactId>docker-maven-plugin</artifactId>
-				<version>0.4.13</version>
-				<configuration>
-					<!-- made of '[a-z0-9-_.]' -->
-					<imageName>${project.artifactId}:${project.version}</imageName>
-					<dockerDirectory>${project.basedir}</dockerDirectory>
-					<resources>
-						<resource>
-							<targetPath>/</targetPath>
-							<directory>${project.build.directory}</directory>
-							<include>${project.build.finalName}.jar</include>
-						</resource>
-					</resources>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${spring-boot.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <layout>ZIP</layout>
+        </configuration>
+      </plugin>
+      <!-- docker -->
+      <plugin>
+        <groupId>com.spotify</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <version>0.4.13</version>
+        <configuration>
+          <!-- made of '[a-z0-9-_.]' -->
+          <imageName>${project.artifactId}:${project.version}</imageName>
+          <dockerDirectory>${project.basedir}</dockerDirectory>
+          <resources>
+            <resource>
+              <targetPath>/</targetPath>
+              <directory>${project.build.directory}</directory>
+              <include>${project.build.finalName}.jar</include>
+            </resource>
+          </resources>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/xxl-job-extension/job-auto-register/pom.xml
+++ b/xxl-job-extension/job-auto-register/pom.xml
@@ -1,0 +1,36 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.xuxueli</groupId>
+		<artifactId>xxl-job-extension</artifactId>
+		<version>2.2.0</version>
+	</parent>
+	<artifactId>job-auto-register</artifactId>
+	<packaging>jar</packaging>
+	<name>${project.artifactId}</name>
+	<description>A distributed task scheduling framework.</description>
+	<url>https://www.xuxueli.com/</url>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.xuxueli</groupId>
+			<artifactId>xxl-job-core</artifactId>
+			<version>2.2.0</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.xuxueli</groupId>
+			<artifactId>xxl-job-admin</artifactId>
+			<version>2.2.0</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>1.18.12</version>
+			<scope>compile</scope>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/xxl-job-extension/job-auto-register/src/main/java/com/xxl/job/core/extension/JobAutoRegisterAutoConfiguration.java
+++ b/xxl-job-extension/job-auto-register/src/main/java/com/xxl/job/core/extension/JobAutoRegisterAutoConfiguration.java
@@ -1,0 +1,15 @@
+package com.xxl.job.core.extension;
+
+import com.xxl.job.core.extension.client.TaskContext;
+import com.xxl.job.core.extension.server.RegisterServer;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * @author lesl
+ */
+@Configuration
+@Import({RegisterServer.class, TaskContext.class})
+public class JobAutoRegisterAutoConfiguration {
+
+}

--- a/xxl-job-extension/job-auto-register/src/main/java/com/xxl/job/core/extension/client/RegisterClient.java
+++ b/xxl-job-extension/job-auto-register/src/main/java/com/xxl/job/core/extension/client/RegisterClient.java
@@ -1,0 +1,114 @@
+package com.xxl.job.core.extension.client;
+
+import com.xxl.job.core.executor.XxlJobExecutor;
+import com.xxl.job.core.extension.server.param.JobAutoRegisterParam;
+import com.xxl.job.core.extension.server.param.JobTask;
+import com.xxl.job.core.handler.annotation.XxlJob;
+import com.xxl.job.core.util.XxlJobRemotingUtil;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.SneakyThrows;
+import org.springframework.beans.factory.SmartInitializingSingleton;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * @author lesl
+ */
+@ConditionalOnBean(XxlJobExecutor.class)
+public class RegisterClient implements SmartInitializingSingleton {
+
+	private final Map<Class<? extends Annotation>, BiConsumer<?, JobTask>> annotations;
+
+	private final TaskContext taskContext;
+
+	private final XxlJobExecutor xxlJobExecutor;
+
+	private final String appName;
+
+	private final String appTitle;
+
+	public RegisterClient(String appName, String appTitle, TaskContext taskContext,
+			XxlJobExecutor xxlJobExecutor) {
+		this.appName = appName;
+		this.appTitle = appTitle;
+		this.annotations = new HashMap<>();
+		this.taskContext = taskContext;
+		this.xxlJobExecutor = xxlJobExecutor;
+
+		//设置XXL-Job的转换
+		putAnnotation(XxlJob.class, null);
+	}
+
+	public void enableScheduleSupport() {
+		//设置Spring Scheduled的转换
+		putAnnotation(Scheduled.class, (input, output) -> {
+			String cron = input.cron();
+			if (!"".equals(cron)) {
+				output.setCron(cron);
+			} else {
+				long fixedRate = input.fixedRate();
+				long fixedDelay = input.fixedDelay();
+				// 是否应该转换一下?
+			}
+		});
+	}
+
+	public <T extends Annotation> void putAnnotation(Class<T> annotationClass,
+			BiConsumer<T, JobTask> convertor) {
+		this.annotations.put(annotationClass, convertor);
+	}
+
+	@SneakyThrows
+	@Override
+	public void afterSingletonsInstantiated() {
+
+		// 获取@Schedule, @XXlJob注解列表去注册
+		if (CollectionUtils.isEmpty(annotations)) {
+			return;
+		}
+		List<JobTask> allTaskList = findAllTaskList();
+
+		String address = getFieldValue(xxlJobExecutor, "adminAddresses");
+		String accessToken = getFieldValue(xxlJobExecutor, "accessToken");
+
+		JobAutoRegisterParam autoRegisterParam = new JobAutoRegisterParam();
+		autoRegisterParam.setJobTasks(allTaskList);
+		autoRegisterParam.setAppName(appName);
+		autoRegisterParam.setAppTitle(appTitle);
+
+		XxlJobRemotingUtil
+				.postBody(address + "/api/extension/job-register", accessToken, 3, autoRegisterParam,
+						String.class);
+	}
+
+	@SneakyThrows
+	private String getFieldValue(XxlJobExecutor xxlJobExecutor, String fieldName) {
+		Field field = ReflectionUtils.findField(xxlJobExecutor.getClass(), fieldName);
+		assert field != null;
+		ReflectionUtils.makeAccessible(field);
+		return (String) field.get(xxlJobExecutor);
+	}
+
+	@SuppressWarnings("unchecked")
+	private List<JobTask> findAllTaskList() {
+		Stream<List<JobTask>> listStream = annotations.entrySet()
+				.parallelStream()
+				.map(entry -> {
+					Class key = entry.getKey();
+					BiConsumer value = entry.getValue();
+					return (List<JobTask>) taskContext.findTask(key, value);
+				});
+
+		return listStream.flatMap(Collection::stream).collect(Collectors.toList());
+	}
+}

--- a/xxl-job-extension/job-auto-register/src/main/java/com/xxl/job/core/extension/client/TaskContext.java
+++ b/xxl-job-extension/job-auto-register/src/main/java/com/xxl/job/core/extension/client/TaskContext.java
@@ -58,7 +58,6 @@ public class TaskContext implements ApplicationContextAware {
 					String jobHandler = classSimpleName + "." + methodName;
 					jobTask.setJobHandler(jobHandler);
 					// 因为没有默认值设置不了，所以增加默认值
-					jobTask.setCron("0 0 0 1 1 ?");
 					if(convertor != null) {
 						convertor.accept(value, jobTask);
 					}

--- a/xxl-job-extension/job-auto-register/src/main/java/com/xxl/job/core/extension/client/TaskContext.java
+++ b/xxl-job-extension/job-auto-register/src/main/java/com/xxl/job/core/extension/client/TaskContext.java
@@ -1,0 +1,71 @@
+package com.xxl.job.core.extension.client;
+
+import com.xxl.job.core.extension.server.param.JobTask;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.BiConsumer;
+import org.springframework.beans.BeansException;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.core.MethodIntrospector;
+import org.springframework.core.MethodIntrospector.MetadataLookup;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author lesl
+ */
+@Component
+@ConditionalOnClass(ApplicationContextAware.class)
+public class TaskContext implements ApplicationContextAware {
+
+	private ApplicationContext applicationContext;
+
+	@Override
+	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		this.applicationContext = applicationContext;
+	}
+
+	public <T extends Annotation> List<JobTask> findTask(Class<T> annotationClass
+			, BiConsumer<T, JobTask> convertor) {
+		List<JobTask> result = new ArrayList<>();
+
+		String[] beanDefinitionNames = applicationContext
+				.getBeanNamesForType(Object.class, false, true);
+		for (String beanDefinitionName : beanDefinitionNames) {
+			Object bean = applicationContext.getBean(beanDefinitionName);
+
+			Map<Method, T> annotatedMethods =  MethodIntrospector
+					.selectMethods(bean.getClass(), (MetadataLookup<T>) method
+							-> AnnotatedElementUtils.findMergedAnnotation(method, annotationClass)
+					);
+			if (annotatedMethods.isEmpty()) {
+				continue;
+			}
+
+			for (Entry<Method, T> methodXxlJobEntry : annotatedMethods.entrySet()) {
+				Method method = methodXxlJobEntry.getKey();
+				T value = methodXxlJobEntry.getValue();
+				if (value != null) {
+					JobTask jobTask = new JobTask();
+					String classSimpleName = method.getDeclaringClass().getSimpleName();
+					String methodName = method.getName();
+					String jobHandler = classSimpleName + "." + methodName;
+					jobTask.setJobHandler(jobHandler);
+					// 因为没有默认值设置不了，所以增加默认值
+					jobTask.setCron("0 0 0 1 1 ?");
+					if(convertor != null) {
+						convertor.accept(value, jobTask);
+					}
+					result.add(jobTask);
+				}
+			}
+		}
+		return result;
+	}
+}

--- a/xxl-job-extension/job-auto-register/src/main/java/com/xxl/job/core/extension/server/RegisterServer.java
+++ b/xxl-job-extension/job-auto-register/src/main/java/com/xxl/job/core/extension/server/RegisterServer.java
@@ -1,0 +1,24 @@
+package com.xxl.job.core.extension.server;
+
+import com.xxl.job.admin.XxlJobAdminApplication;
+import com.xxl.job.core.extension.server.controller.JobAutoRegisterController;
+import com.xxl.job.core.extension.server.service.JobAutoRegisterService;
+import javax.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * @author lesl
+ */
+@Slf4j
+@Configuration
+@Import({JobAutoRegisterController.class, JobAutoRegisterService.class})
+@ConditionalOnClass(XxlJobAdminApplication.class)
+public class RegisterServer {
+	@PostConstruct
+	public void init(){
+		log.info(" >>>>>>>>>>>>>>>>>> job-auto-register extension started.");
+	}
+}

--- a/xxl-job-extension/job-auto-register/src/main/java/com/xxl/job/core/extension/server/controller/JobAutoRegisterController.java
+++ b/xxl-job-extension/job-auto-register/src/main/java/com/xxl/job/core/extension/server/controller/JobAutoRegisterController.java
@@ -1,0 +1,36 @@
+package com.xxl.job.core.extension.server.controller;
+
+import com.xxl.job.admin.controller.annotation.PermissionLimit;
+import com.xxl.job.admin.core.model.XxlJobGroup;
+import com.xxl.job.core.biz.model.ReturnT;
+import com.xxl.job.core.extension.server.param.JobAutoRegisterParam;
+import com.xxl.job.core.extension.server.service.JobAutoRegisterService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author lesl
+ */
+@RestController
+@RequestMapping("/api/extension")
+public class JobAutoRegisterController {
+
+	@Autowired
+	JobAutoRegisterService jobAutoRegisterService;
+
+	@RequestMapping("/job-register")
+	@ResponseBody
+	@PermissionLimit(limit = false)
+	public ReturnT<String> api(@RequestBody JobAutoRegisterParam param) {
+		XxlJobGroup xxlJobGroup = jobAutoRegisterService.createGroupIfAbsent(param);
+
+		int groupId = xxlJobGroup.getId();
+
+		jobAutoRegisterService.createTaskIfAbsent(groupId, param);
+
+		return ReturnT.SUCCESS;
+	}
+}

--- a/xxl-job-extension/job-auto-register/src/main/java/com/xxl/job/core/extension/server/param/JobAutoRegisterParam.java
+++ b/xxl-job-extension/job-auto-register/src/main/java/com/xxl/job/core/extension/server/param/JobAutoRegisterParam.java
@@ -1,0 +1,25 @@
+package com.xxl.job.core.extension.server.param;
+
+import java.util.List;
+import lombok.Data;
+
+/**
+ * @author lesl
+ */
+@Data
+public class JobAutoRegisterParam {
+
+	/**
+	 * app名称
+	 */
+	private String appName;
+
+	/**
+	 * app 标题
+	 */
+	private String appTitle;
+	/**
+	 * 任务列表
+	 */
+	private List<JobTask> jobTasks;
+}

--- a/xxl-job-extension/job-auto-register/src/main/java/com/xxl/job/core/extension/server/param/JobTask.java
+++ b/xxl-job-extension/job-auto-register/src/main/java/com/xxl/job/core/extension/server/param/JobTask.java
@@ -1,0 +1,20 @@
+package com.xxl.job.core.extension.server.param;
+
+import lombok.Data;
+
+/**
+ * @author lesl
+ */
+@Data
+public class JobTask {
+
+	/**
+	 * cron 表达式
+	 */
+	private String cron;
+
+	/**
+	 * JobHandler
+	 */
+	private String jobHandler;
+}

--- a/xxl-job-extension/job-auto-register/src/main/java/com/xxl/job/core/extension/server/service/JobAutoRegisterService.java
+++ b/xxl-job-extension/job-auto-register/src/main/java/com/xxl/job/core/extension/server/service/JobAutoRegisterService.java
@@ -1,0 +1,93 @@
+package com.xxl.job.core.extension.server.service;
+
+import com.xxl.job.admin.core.model.XxlJobGroup;
+import com.xxl.job.admin.core.model.XxlJobInfo;
+import com.xxl.job.admin.dao.XxlJobGroupDao;
+import com.xxl.job.admin.service.XxlJobService;
+import com.xxl.job.core.biz.model.ReturnT;
+import com.xxl.job.core.extension.server.param.JobAutoRegisterParam;
+import com.xxl.job.core.extension.server.param.JobTask;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author lesl
+ */
+@Slf4j
+@Service
+public class JobAutoRegisterService {
+
+	@Autowired
+	XxlJobGroupDao xxlJobGroupDao;
+
+	@Autowired
+	XxlJobService xxlJobService;
+
+	public XxlJobGroup createGroupIfAbsent(JobAutoRegisterParam param) {
+		String appName = param.getAppName();
+		return Optional.ofNullable(getGroupByAppName(appName))
+				.orElseGet(() -> createGroup(param));
+	}
+
+	private XxlJobGroup getGroupByAppName(String appName) {
+		// 查找appName 是否存在, 如果不存在则新建
+		List<XxlJobGroup> xxlJobGroups = xxlJobGroupDao.pageList(0, 10, appName, null);
+		return xxlJobGroups.stream()
+				.filter(d -> d.getAppname().equals(appName))
+				.findFirst()
+				.orElse(null);
+	}
+
+	private XxlJobGroup createGroup(JobAutoRegisterParam param) {
+		XxlJobGroup xxlJobGroup = new XxlJobGroup();
+		xxlJobGroup.setAddressList(null);
+		xxlJobGroup.setAddressType(0);
+		xxlJobGroup.setAppname(param.getAppName());
+		xxlJobGroup.setTitle(param.getAppTitle());
+		xxlJobGroupDao.save(xxlJobGroup);
+		return getGroupByAppName(param.getAppName());
+	}
+
+
+	private XxlJobInfo getTaskJobHandler(int groupId, String jobHandler) {
+		Map<String, Object> stringObjectMap = xxlJobService
+				.pageList(0, 10, groupId, -1, null, jobHandler, "");
+
+		@SuppressWarnings("unchecked")
+		List<XxlJobInfo> data = (List<XxlJobInfo>) stringObjectMap.get("data");
+		return data.stream()
+				.filter(v -> v.getExecutorHandler().equals(jobHandler))
+				.findFirst()
+				.orElse(null);
+	}
+
+	private void createTaskJob(int groupId, JobTask jobTask) {
+		XxlJobInfo xxlJobInfo = new XxlJobInfo();
+		xxlJobInfo.setJobGroup(groupId);
+		xxlJobInfo.setJobCron(jobTask.getCron());
+		xxlJobInfo.setJobDesc(jobTask.getJobHandler());
+		xxlJobInfo.setExecutorRouteStrategy("FIRST");
+		xxlJobInfo.setExecutorBlockStrategy("SERIAL_EXECUTION");
+		xxlJobInfo.setExecutorHandler(jobTask.getJobHandler());
+		xxlJobInfo.setAuthor("无");
+		xxlJobInfo.setGlueType("BEAN");
+		ReturnT<String> addResult = xxlJobService.add(xxlJobInfo);
+		if(addResult.getCode() != ReturnT.SUCCESS_CODE){
+			log.error("add task job failed, {}", addResult.getMsg());
+		}
+	}
+
+
+	public void createTaskIfAbsent(int groupId, JobAutoRegisterParam param) {
+		param.getJobTasks().forEach(jobTask -> {
+			XxlJobInfo taskJobHandler = getTaskJobHandler(groupId, jobTask.getJobHandler());
+			if(taskJobHandler == null){
+				createTaskJob(groupId, jobTask);
+			}
+		});
+	}
+}

--- a/xxl-job-extension/job-auto-register/src/main/resources/META-INF/spring.factories
+++ b/xxl-job-extension/job-auto-register/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+  com.xxl.job.core.extension.JobAutoRegisterAutoConfiguration

--- a/xxl-job-extension/pom.xml
+++ b/xxl-job-extension/pom.xml
@@ -1,0 +1,20 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.xuxueli</groupId>
+		<artifactId>xxl-job</artifactId>
+		<version>2.2.0</version>
+	</parent>
+	<artifactId>xxl-job-extension</artifactId>
+	<packaging>pom</packaging>
+
+	<name>${project.artifactId}</name>
+	<description>A distributed task scheduling framework.</description>
+	<url>https://www.xuxueli.com/</url>
+
+	<modules>
+		<module>job-auto-register</module>
+	</modules>
+
+</project>


### PR DESCRIPTION
增加自动注册功能，对原来的代码零侵入，增加job-auto-register模块

#### 服务端
``` shell
启动服务
java -Dloader.path=./lib -jar xxl-job-admin-2.2.0.jar
将job-auto-register-2.2.0.jar 放入./lib目录
```
>  xxl-job-admin-2.2.0.jar 需要重新打包，spring-boot-maven-plugin->layout 修改为ZIP
>  因为默认不支持 -Dloader.path 参数
>  原因参考[官方文档](https://docs.spring.io/spring-boot/docs/current/reference/html/appendix-executable-jar-format.html#executable-jar-restrictions)

#### 客户端
加入此依赖，并且初始化RegisterClient即可，如下所示，理论上注册一次之后可以去掉此代码
``` java
@Bean
public RegisterClient registerClient(TaskContext taskContext, XxlJobExecutor xxlJobExecutor) {

  RegisterClient registerClient = new RegisterClient(appName, appTitle, taskContext,
		  xxlJobExecutor);
  registerClient.enableScheduleSupport();
  return registerClient;
}
```