### PR TITLE
任务管理页面的运行模式，使用英文冒号

### DIFF
--- a/xxl-job-admin/src/main/resources/static/js/jobinfo.index.1.js
+++ b/xxl-job-admin/src/main/resources/static/js/jobinfo.index.1.js
@@ -67,7 +67,7 @@ $(function() {
 						"render": function ( data, type, row ) {
 							var glueTypeTitle = findGlueTypeTitle(row.glueType);
                             if (row.executorHandler) {
-                                return glueTypeTitle +"：" + row.executorHandler;
+                                return glueTypeTitle +": " + row.executorHandler;
                             } else {
                                 return glueTypeTitle;
                             }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**
在任务管理页面，期望双击“运行模式”时，只选中 JobHandler 名称，如图：
![位置](https://user-images.githubusercontent.com/9838749/120131035-1d26d100-c1fa-11eb-8fb0-ff32ac550408.jpg)
![英文冒号](https://user-images.githubusercontent.com/9838749/120130700-64609200-c1f9-11eb-936b-e1ac1b47a27c.gif)

但是现状是双击“运行模式”时，选中了 "Bean：" + JobHandler 名称，如图：
![中文冒号](https://user-images.githubusercontent.com/9838749/120130942-eb156f00-c1f9-11eb-8043-686ec773c04d.gif)

**Other information:**