### PR TITLE
BugFix XxlJobLogMapper.xml 中的 findLogReport 统计日报结果为空情况下设定默认值

### DIFF
--- a/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobLogMapper.xml
+++ b/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobLogMapper.xml
@@ -178,9 +178,9 @@
 
     <select id="findLogReport" resultType="java.util.Map" >
 		SELECT
-			COUNT(handle_code) triggerDayCount,
-			SUM(CASE WHEN (trigger_code in (0, 200) and handle_code = 0) then 1 else 0 end) as triggerDayCountRunning,
-			SUM(CASE WHEN handle_code = 200 then 1 else 0 end) as triggerDayCountSuc
+			IFNULL(COUNT(handle_code),0) triggerDayCount,
+			IFNULL(SUM(CASE WHEN (trigger_code in (0, 200) and handle_code = 0) then 1 else 0 end),0) as triggerDayCountRunning,
+			IFNULL(SUM(CASE WHEN handle_code = 200 then 1 else 0 end),0) as triggerDayCountSuc
 		FROM xxl_job_log
 		WHERE trigger_time BETWEEN #{from} and #{to}
     </select>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [√] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**
fix XxlJobLogMapper.xml 中的 findLogReport 查询方法，当某天的统计数据为空时，SUM运算符统计结果为null，导致 JobLogReportHelper 中使用 Integer.valueOf 方法解析结果参数出现 NPE。
解决方法：在 XxlJobLogMapper SQL查询方法语句中套上一层 IFNULL(SUM(xx),0) 语句赋予默认值。

**Other information:**