### PR TITLE
优化设置任务超时参数情况下的线程频繁创建问题

### DIFF
--- a/xxl-job-core/src/main/java/com/xxl/job/core/thread/JobThread.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/thread/JobThread.java
@@ -107,7 +107,7 @@ public class JobThread extends Thread{
 
             TriggerParam triggerParam = null;
             try {
-				// to check toStop signal, we need cycle, so wo cannot use queue.take(), instand of poll(timeout)
+				// to check toStop signal, we need cycle, so we cannot use queue.take(), instead of poll(timeout)
 				triggerParam = triggerQueue.poll(3L, TimeUnit.SECONDS);
 				if (triggerParam!=null) {
 					running = true;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [√] Bugfix
- [ ] Feature
- [ ] Code style update
- [√] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**

当任务设置了超时时间后，原先的做法是new一个新线程，交给新线程去执行。当任务多且频繁调用时，这么做会增加线程创建销毁的开销。如果使用线程池进行维护，一定程度上可以做到线程复用。
要特别说明的是：我把maximumPoolSize设置为Integer.MAX_VALUE，是因为不想让线程池使本应该准确执行的任务而延期执行因为如果设置了worker上限，那么也意味着其余task必须等待，严重时可能会造成任务执行时间比预期执行时间要晚。潜在问题是可能因为线程无限创建而导致OOM，但这个问题在原先的做法下也可能会发生。

**Other information:**