### PR TITLE
[issue-2563] 当登录用户只有一个执行器权限进入调度日志模块，任务下拉框只有“全部”这个选项

### DIFF
--- a/xxl-job-admin/src/main/resources/static/js/joblog.index.1.js
+++ b/xxl-job-admin/src/main/resources/static/js/joblog.index.1.js
@@ -29,10 +29,12 @@ $(function() {
 			},
 		});
 	});
+
 	if ($("#jobGroup").attr("paramVal")){
 		$("#jobGroup").find("option[value='" + $("#jobGroup").attr("paramVal") + "']").attr("selected",true);
-        $("#jobGroup").change();
 	}
+
+	$("#jobGroup").change();
 
 	// filter Time
     var rangesConf = {};


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix


**The description of the PR:**
This pr relates to [issues-2563](https://github.com/xuxueli/xxl-job/issues/2563).
