### PR TITLE
删除一些警告，提高代码质量，没有任何风险

### DIFF
--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/controller/JobApiController.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/controller/JobApiController.java
@@ -42,15 +42,15 @@ public class JobApiController {
 
         // valid
         if (!"POST".equalsIgnoreCase(request.getMethod())) {
-            return new ReturnT<String>(ReturnT.FAIL_CODE, "invalid request, HttpMethod not support.");
+            return new ReturnT<>(ReturnT.FAIL_CODE, "invalid request, HttpMethod not support.");
         }
         if (uri==null || uri.trim().length()==0) {
-            return new ReturnT<String>(ReturnT.FAIL_CODE, "invalid request, uri-mapping empty.");
+            return new ReturnT<>(ReturnT.FAIL_CODE, "invalid request, uri-mapping empty.");
         }
         if (XxlJobAdminConfig.getAdminConfig().getAccessToken()!=null
                 && XxlJobAdminConfig.getAdminConfig().getAccessToken().trim().length()>0
                 && !XxlJobAdminConfig.getAdminConfig().getAccessToken().equals(request.getHeader(XxlJobRemotingUtil.XXL_JOB_ACCESS_TOKEN))) {
-            return new ReturnT<String>(ReturnT.FAIL_CODE, "The access token is wrong.");
+            return new ReturnT<>(ReturnT.FAIL_CODE, "The access token is wrong.");
         }
 
         // services mapping
@@ -64,7 +64,7 @@ public class JobApiController {
             RegistryParam registryParam = GsonTool.fromJson(data, RegistryParam.class);
             return adminBiz.registryRemove(registryParam);
         } else {
-            return new ReturnT<String>(ReturnT.FAIL_CODE, "invalid request, uri-mapping("+ uri +") not found.");
+            return new ReturnT<>(ReturnT.FAIL_CODE, "invalid request, uri-mapping("+ uri +") not found.");
         }
 
     }

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/thread/JobCompleteHelper.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/thread/JobCompleteHelper.java
@@ -155,14 +155,14 @@ public class JobCompleteHelper {
 		// valid log item
 		XxlJobLog log = XxlJobAdminConfig.getAdminConfig().getXxlJobLogDao().load(handleCallbackParam.getLogId());
 		if (log == null) {
-			return new ReturnT<String>(ReturnT.FAIL_CODE, "log item not found.");
+			return new ReturnT<>(ReturnT.FAIL_CODE, "log item not found.");
 		}
 		if (log.getHandleCode() > 0) {
-			return new ReturnT<String>(ReturnT.FAIL_CODE, "log repeate callback.");     // avoid repeat callback, trigger child job etc
+			return new ReturnT<>(ReturnT.FAIL_CODE, "log repeate callback.");     // avoid repeat callback, trigger child job etc
 		}
 
 		// handle msg
-		StringBuffer handleMsg = new StringBuffer();
+		StringBuilder handleMsg = new StringBuilder();
 		if (log.getHandleMsg()!=null) {
 			handleMsg.append(log.getHandleMsg()).append("<br>");
 		}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/thread/JobLogReportHelper.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/thread/JobLogReportHelper.java
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeUnit;
  * @author xuxueli 2019-11-22
  */
 public class JobLogReportHelper {
-    private static Logger logger = LoggerFactory.getLogger(JobLogReportHelper.class);
+    private static final Logger logger = LoggerFactory.getLogger(JobLogReportHelper.class);
 
     private static JobLogReportHelper instance = new JobLogReportHelper();
     public static JobLogReportHelper getInstance(){
@@ -70,9 +70,9 @@ public class JobLogReportHelper {
 
                             Map<String, Object> triggerCountMap = XxlJobAdminConfig.getAdminConfig().getXxlJobLogDao().findLogReport(todayFrom, todayTo);
                             if (triggerCountMap!=null && triggerCountMap.size()>0) {
-                                int triggerDayCount = triggerCountMap.containsKey("triggerDayCount")?Integer.valueOf(String.valueOf(triggerCountMap.get("triggerDayCount"))):0;
-                                int triggerDayCountRunning = triggerCountMap.containsKey("triggerDayCountRunning")?Integer.valueOf(String.valueOf(triggerCountMap.get("triggerDayCountRunning"))):0;
-                                int triggerDayCountSuc = triggerCountMap.containsKey("triggerDayCountSuc")?Integer.valueOf(String.valueOf(triggerCountMap.get("triggerDayCountSuc"))):0;
+                                int triggerDayCount = triggerCountMap.containsKey("triggerDayCount")?Integer.parseInt(String.valueOf(triggerCountMap.get("triggerDayCount"))):0;
+                                int triggerDayCountRunning = triggerCountMap.containsKey("triggerDayCountRunning")?Integer.parseInt(String.valueOf(triggerCountMap.get("triggerDayCountRunning"))):0;
+                                int triggerDayCountSuc = triggerCountMap.containsKey("triggerDayCountSuc")?Integer.parseInt(String.valueOf(triggerCountMap.get("triggerDayCountSuc"))):0;
                                 int triggerDayCountFail = triggerDayCount - triggerDayCountRunning - triggerDayCountSuc;
 
                                 xxlJobLogReport.setRunningCount(triggerDayCountRunning);
@@ -89,7 +89,7 @@ public class JobLogReportHelper {
 
                     } catch (Exception e) {
                         if (!toStop) {
-                            logger.error(">>>>>>>>>>> xxl-job, job log report thread error:{}", e);
+                            logger.error(">>>>>>>>>>> xxl-job, job log report thread error:", e);
                         }
                     }
 

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/thread/JobRegistryHelper.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/thread/JobRegistryHelper.java
@@ -37,7 +37,7 @@ public class JobRegistryHelper {
 				10,
 				30L,
 				TimeUnit.SECONDS,
-				new LinkedBlockingQueue<Runnable>(2000),
+				new LinkedBlockingQueue<>(2000),
 				new ThreadFactory() {
 					@Override
 					public Thread newThread(Runnable r) {
@@ -69,7 +69,7 @@ public class JobRegistryHelper {
 							}
 
 							// fresh online address (admin/executor)
-							HashMap<String, List<String>> appAddressMap = new HashMap<String, List<String>>();
+							HashMap<String, List<String>> appAddressMap = new HashMap<>();
 							List<XxlJobRegistry> list = XxlJobAdminConfig.getAdminConfig().getXxlJobRegistryDao().findAll(RegistryConfig.DEAD_TIMEOUT, new Date());
 							if (list != null) {
 								for (XxlJobRegistry item: list) {
@@ -77,7 +77,7 @@ public class JobRegistryHelper {
 										String appname = item.getRegistryKey();
 										List<String> registryList = appAddressMap.get(appname);
 										if (registryList == null) {
-											registryList = new ArrayList<String>();
+											registryList = new ArrayList<>();
 										}
 
 										if (!registryList.contains(item.getRegistryValue())) {
@@ -109,14 +109,14 @@ public class JobRegistryHelper {
 						}
 					} catch (Exception e) {
 						if (!toStop) {
-							logger.error(">>>>>>>>>>> xxl-job, job registry monitor thread error:{}", e);
+							logger.error(">>>>>>>>>>> xxl-job, job registry monitor thread error:", e);
 						}
 					}
 					try {
 						TimeUnit.SECONDS.sleep(RegistryConfig.BEAT_TIMEOUT);
 					} catch (InterruptedException e) {
 						if (!toStop) {
-							logger.error(">>>>>>>>>>> xxl-job, job registry monitor thread error:{}", e);
+							logger.error(">>>>>>>>>>> xxl-job, job registry monitor thread error:", e);
 						}
 					}
 				}
@@ -152,7 +152,7 @@ public class JobRegistryHelper {
 		if (!StringUtils.hasText(registryParam.getRegistryGroup())
 				|| !StringUtils.hasText(registryParam.getRegistryKey())
 				|| !StringUtils.hasText(registryParam.getRegistryValue())) {
-			return new ReturnT<String>(ReturnT.FAIL_CODE, "Illegal Argument.");
+			return new ReturnT<>(ReturnT.FAIL_CODE, "Illegal Argument.");
 		}
 
 		// async execute

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/trigger/XxlJobTrigger.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/trigger/XxlJobTrigger.java
@@ -72,8 +72,8 @@ public class XxlJobTrigger {
             String[] shardingArr = executorShardingParam.split("/");
             if (shardingArr.length==2 && isNumeric(shardingArr[0]) && isNumeric(shardingArr[1])) {
                 shardingParam = new int[2];
-                shardingParam[0] = Integer.valueOf(shardingArr[0]);
-                shardingParam[1] = Integer.valueOf(shardingArr[1]);
+                shardingParam[0] = Integer.parseInt(shardingArr[0]);
+                shardingParam[1] = Integer.parseInt(shardingArr[1]);
             }
         }
         if (ExecutorRouteStrategyEnum.SHARDING_BROADCAST==ExecutorRouteStrategyEnum.match(jobInfo.getExecutorRouteStrategy(), null)
@@ -93,7 +93,7 @@ public class XxlJobTrigger {
 
     private static boolean isNumeric(String str){
         try {
-            int result = Integer.valueOf(str);
+            Integer.parseInt(str);
             return true;
         } catch (NumberFormatException e) {
             return false;
@@ -155,7 +155,7 @@ public class XxlJobTrigger {
                 }
             }
         } else {
-            routeAddressResult = new ReturnT<String>(ReturnT.FAIL_CODE, I18nUtil.getString("jobconf_trigger_address_empty"));
+            routeAddressResult = new ReturnT<>(ReturnT.FAIL_CODE, I18nUtil.getString("jobconf_trigger_address_empty"));
         }
 
         // 4、trigger remote executor
@@ -163,11 +163,11 @@ public class XxlJobTrigger {
         if (address != null) {
             triggerResult = runExecutor(triggerParam, address);
         } else {
-            triggerResult = new ReturnT<String>(ReturnT.FAIL_CODE, null);
+            triggerResult = new ReturnT<>(ReturnT.FAIL_CODE, null);
         }
 
         // 5、collection trigger info
-        StringBuffer triggerMsgSb = new StringBuffer();
+        StringBuilder triggerMsgSb = new StringBuilder();
         triggerMsgSb.append(I18nUtil.getString("jobconf_trigger_type")).append("：").append(triggerType.getTitle());
         triggerMsgSb.append("<br>").append(I18nUtil.getString("jobconf_trigger_admin_adress")).append("：").append(IpUtil.getIp());
         triggerMsgSb.append("<br>").append(I18nUtil.getString("jobconf_trigger_exe_regtype")).append("：")
@@ -211,10 +211,10 @@ public class XxlJobTrigger {
             runResult = executorBiz.run(triggerParam);
         } catch (Exception e) {
             logger.error(">>>>>>>>>>> xxl-job trigger error, please check if the executor[{}] is running.", address, e);
-            runResult = new ReturnT<String>(ReturnT.FAIL_CODE, ThrowableUtil.toString(e));
+            runResult = new ReturnT<>(ReturnT.FAIL_CODE, ThrowableUtil.toString(e));
         }
 
-        StringBuffer runResultSB = new StringBuffer(I18nUtil.getString("jobconf_trigger_run") + "：");
+        StringBuilder runResultSB = new StringBuilder(I18nUtil.getString("jobconf_trigger_run") + "：");
         runResultSB.append("<br>address：").append(address);
         runResultSB.append("<br>code：").append(runResult.getCode());
         runResultSB.append("<br>msg：").append(runResult.getMsg());

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobGroupDao.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobGroupDao.java
@@ -12,26 +12,26 @@ import java.util.List;
 @Mapper
 public interface XxlJobGroupDao {
 
-    public List<XxlJobGroup> findAll();
+    List<XxlJobGroup> findAll();
 
-    public List<XxlJobGroup> findByAddressType(@Param("addressType") int addressType);
+    List<XxlJobGroup> findByAddressType(@Param("addressType") int addressType);
 
-    public int save(XxlJobGroup xxlJobGroup);
+    int save(XxlJobGroup xxlJobGroup);
 
-    public int update(XxlJobGroup xxlJobGroup);
+    int update(XxlJobGroup xxlJobGroup);
 
-    public int remove(@Param("id") int id);
+    int remove(@Param("id") int id);
 
-    public XxlJobGroup load(@Param("id") int id);
+    XxlJobGroup load(@Param("id") int id);
 
-    public List<XxlJobGroup> pageList(@Param("offset") int offset,
-                                      @Param("pagesize") int pagesize,
-                                      @Param("appname") String appname,
-                                      @Param("title") String title);
+    List<XxlJobGroup> pageList(@Param("offset") int offset,
+                               @Param("pagesize") int pagesize,
+                               @Param("appname") String appname,
+                               @Param("title") String title);
 
-    public int pageListCount(@Param("offset") int offset,
-                             @Param("pagesize") int pagesize,
-                             @Param("appname") String appname,
-                             @Param("title") String title);
+    int pageListCount(@Param("offset") int offset,
+                      @Param("pagesize") int pagesize,
+                      @Param("appname") String appname,
+                      @Param("title") String title);
 
 }

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobInfoDao.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobInfoDao.java
@@ -14,36 +14,36 @@ import java.util.List;
 @Mapper
 public interface XxlJobInfoDao {
 
-	public List<XxlJobInfo> pageList(@Param("offset") int offset,
-									 @Param("pagesize") int pagesize,
-									 @Param("jobGroup") int jobGroup,
-									 @Param("triggerStatus") int triggerStatus,
-									 @Param("jobDesc") String jobDesc,
-									 @Param("executorHandler") String executorHandler,
-									 @Param("author") String author);
-	public int pageListCount(@Param("offset") int offset,
-							 @Param("pagesize") int pagesize,
-							 @Param("jobGroup") int jobGroup,
-							 @Param("triggerStatus") int triggerStatus,
-							 @Param("jobDesc") String jobDesc,
-							 @Param("executorHandler") String executorHandler,
-							 @Param("author") String author);
+	List<XxlJobInfo> pageList(@Param("offset") int offset,
+								 @Param("pagesize") int pagesize,
+								 @Param("jobGroup") int jobGroup,
+								 @Param("triggerStatus") int triggerStatus,
+								 @Param("jobDesc") String jobDesc,
+								 @Param("executorHandler") String executorHandler,
+								 @Param("author") String author);
+	int pageListCount(@Param("offset") int offset,
+						 @Param("pagesize") int pagesize,
+						 @Param("jobGroup") int jobGroup,
+						 @Param("triggerStatus") int triggerStatus,
+						 @Param("jobDesc") String jobDesc,
+						 @Param("executorHandler") String executorHandler,
+						 @Param("author") String author);
 	
-	public int save(XxlJobInfo info);
+	int save(XxlJobInfo info);
 
-	public XxlJobInfo loadById(@Param("id") int id);
+	XxlJobInfo loadById(@Param("id") int id);
 	
-	public int update(XxlJobInfo xxlJobInfo);
+	int update(XxlJobInfo xxlJobInfo);
 	
-	public int delete(@Param("id") long id);
+	int delete(@Param("id") long id);
 
-	public List<XxlJobInfo> getJobsByGroup(@Param("jobGroup") int jobGroup);
+	List<XxlJobInfo> getJobsByGroup(@Param("jobGroup") int jobGroup);
 
-	public int findAllCount();
+	int findAllCount();
 
-	public List<XxlJobInfo> scheduleJobQuery(@Param("maxNextTime") long maxNextTime, @Param("pagesize") int pagesize );
+	List<XxlJobInfo> scheduleJobQuery(@Param("maxNextTime") long maxNextTime, @Param("pagesize") int pagesize );
 
-	public int scheduleUpdate(XxlJobInfo xxlJobInfo);
+	int scheduleUpdate(XxlJobInfo xxlJobInfo);
 
 
 }

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobLogDao.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobLogDao.java
@@ -16,47 +16,47 @@ import java.util.Map;
 public interface XxlJobLogDao {
 
 	// exist jobId not use jobGroup, not exist use jobGroup
-	public List<XxlJobLog> pageList(@Param("offset") int offset,
-									@Param("pagesize") int pagesize,
-									@Param("jobGroup") int jobGroup,
-									@Param("jobId") int jobId,
-									@Param("triggerTimeStart") Date triggerTimeStart,
-									@Param("triggerTimeEnd") Date triggerTimeEnd,
-									@Param("logStatus") int logStatus);
-	public int pageListCount(@Param("offset") int offset,
-							 @Param("pagesize") int pagesize,
-							 @Param("jobGroup") int jobGroup,
-							 @Param("jobId") int jobId,
-							 @Param("triggerTimeStart") Date triggerTimeStart,
-							 @Param("triggerTimeEnd") Date triggerTimeEnd,
-							 @Param("logStatus") int logStatus);
+	List<XxlJobLog> pageList(@Param("offset") int offset,
+								@Param("pagesize") int pagesize,
+								@Param("jobGroup") int jobGroup,
+								@Param("jobId") int jobId,
+								@Param("triggerTimeStart") Date triggerTimeStart,
+								@Param("triggerTimeEnd") Date triggerTimeEnd,
+								@Param("logStatus") int logStatus);
+	int pageListCount(@Param("offset") int offset,
+						 @Param("pagesize") int pagesize,
+						 @Param("jobGroup") int jobGroup,
+						 @Param("jobId") int jobId,
+						 @Param("triggerTimeStart") Date triggerTimeStart,
+						 @Param("triggerTimeEnd") Date triggerTimeEnd,
+						 @Param("logStatus") int logStatus);
 	
-	public XxlJobLog load(@Param("id") long id);
+	XxlJobLog load(@Param("id") long id);
 
-	public long save(XxlJobLog xxlJobLog);
+	long save(XxlJobLog xxlJobLog);
 
-	public int updateTriggerInfo(XxlJobLog xxlJobLog);
+	int updateTriggerInfo(XxlJobLog xxlJobLog);
 
-	public int updateHandleInfo(XxlJobLog xxlJobLog);
+	int updateHandleInfo(XxlJobLog xxlJobLog);
 	
-	public int delete(@Param("jobId") int jobId);
+	int delete(@Param("jobId") int jobId);
 
-	public Map<String, Object> findLogReport(@Param("from") Date from,
-											 @Param("to") Date to);
+	Map<String, Object> findLogReport(@Param("from") Date from,
+										 @Param("to") Date to);
 
-	public List<Long> findClearLogIds(@Param("jobGroup") int jobGroup,
-									  @Param("jobId") int jobId,
-									  @Param("clearBeforeTime") Date clearBeforeTime,
-									  @Param("clearBeforeNum") int clearBeforeNum,
-									  @Param("pagesize") int pagesize);
-	public int clearLog(@Param("logIds") List<Long> logIds);
+	List<Long> findClearLogIds(@Param("jobGroup") int jobGroup,
+								  @Param("jobId") int jobId,
+								  @Param("clearBeforeTime") Date clearBeforeTime,
+								  @Param("clearBeforeNum") int clearBeforeNum,
+								  @Param("pagesize") int pagesize);
+	int clearLog(@Param("logIds") List<Long> logIds);
 
-	public List<Long> findFailJobLogIds(@Param("pagesize") int pagesize);
+	List<Long> findFailJobLogIds(@Param("pagesize") int pagesize);
 
-	public int updateAlarmStatus(@Param("logId") long logId,
-								 @Param("oldAlarmStatus") int oldAlarmStatus,
-								 @Param("newAlarmStatus") int newAlarmStatus);
+	int updateAlarmStatus(@Param("logId") long logId,
+							 @Param("oldAlarmStatus") int oldAlarmStatus,
+							 @Param("newAlarmStatus") int newAlarmStatus);
 
-	public List<Long> findLostJobIds(@Param("losedTime") Date losedTime);
+	List<Long> findLostJobIds(@Param("losedTime") Date losedTime);
 
 }

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobLogGlueDao.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobLogGlueDao.java
@@ -13,12 +13,12 @@ import java.util.List;
 @Mapper
 public interface XxlJobLogGlueDao {
 	
-	public int save(XxlJobLogGlue xxlJobLogGlue);
+	int save(XxlJobLogGlue xxlJobLogGlue);
 	
-	public List<XxlJobLogGlue> findByJobId(@Param("jobId") int jobId);
+	List<XxlJobLogGlue> findByJobId(@Param("jobId") int jobId);
 
-	public int removeOld(@Param("jobId") int jobId, @Param("limit") int limit);
+	int removeOld(@Param("jobId") int jobId, @Param("limit") int limit);
 
-	public int deleteByJobId(@Param("jobId") int jobId);
+	int deleteByJobId(@Param("jobId") int jobId);
 	
 }

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobLogReportDao.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobLogReportDao.java
@@ -14,13 +14,13 @@ import java.util.List;
 @Mapper
 public interface XxlJobLogReportDao {
 
-	public int save(XxlJobLogReport xxlJobLogReport);
+	int save(XxlJobLogReport xxlJobLogReport);
 
-	public int update(XxlJobLogReport xxlJobLogReport);
+	int update(XxlJobLogReport xxlJobLogReport);
 
-	public List<XxlJobLogReport> queryLogReport(@Param("triggerDayFrom") Date triggerDayFrom,
-												@Param("triggerDayTo") Date triggerDayTo);
+	List<XxlJobLogReport> queryLogReport(@Param("triggerDayFrom") Date triggerDayFrom,
+											@Param("triggerDayTo") Date triggerDayTo);
 
-	public XxlJobLogReport queryLogReportTotal();
+	XxlJobLogReport queryLogReportTotal();
 
 }

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobRegistryDao.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobRegistryDao.java
@@ -13,25 +13,25 @@ import java.util.List;
 @Mapper
 public interface XxlJobRegistryDao {
 
-    public List<Integer> findDead(@Param("timeout") int timeout,
-                                  @Param("nowTime") Date nowTime);
+    List<Integer> findDead(@Param("timeout") int timeout,
+                           @Param("nowTime") Date nowTime);
 
-    public int removeDead(@Param("ids") List<Integer> ids);
+    int removeDead(@Param("ids") List<Integer> ids);
 
-    public List<XxlJobRegistry> findAll(@Param("timeout") int timeout,
-                                        @Param("nowTime") Date nowTime);
+    List<XxlJobRegistry> findAll(@Param("timeout") int timeout,
+                                 @Param("nowTime") Date nowTime);
 
-    public int registryUpdate(@Param("registryGroup") String registryGroup,
-                              @Param("registryKey") String registryKey,
-                              @Param("registryValue") String registryValue,
-                              @Param("updateTime") Date updateTime);
+    int registryUpdate(@Param("registryGroup") String registryGroup,
+                       @Param("registryKey") String registryKey,
+                       @Param("registryValue") String registryValue,
+                       @Param("updateTime") Date updateTime);
 
-    public int registrySave(@Param("registryGroup") String registryGroup,
-                            @Param("registryKey") String registryKey,
-                            @Param("registryValue") String registryValue,
-                            @Param("updateTime") Date updateTime);
+    int registrySave(@Param("registryGroup") String registryGroup,
+                     @Param("registryKey") String registryKey,
+                     @Param("registryValue") String registryValue,
+                     @Param("updateTime") Date updateTime);
 
-    public int registryDelete(@Param("registryGroup") String registryGroup,
+    int registryDelete(@Param("registryGroup") String registryGroup,
                           @Param("registryKey") String registryKey,
                           @Param("registryValue") String registryValue);
 

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobUserDao.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobUserDao.java
@@ -11,21 +11,21 @@ import java.util.List;
 @Mapper
 public interface XxlJobUserDao {
 
-	public List<XxlJobUser> pageList(@Param("offset") int offset,
-                                     @Param("pagesize") int pagesize,
-                                     @Param("username") String username,
-									 @Param("role") int role);
-	public int pageListCount(@Param("offset") int offset,
-							 @Param("pagesize") int pagesize,
-							 @Param("username") String username,
-							 @Param("role") int role);
+	List<XxlJobUser> pageList(@Param("offset") int offset,
+                              @Param("pagesize") int pagesize,
+                              @Param("username") String username,
+								 @Param("role") int role);
+	int pageListCount(@Param("offset") int offset,
+						 @Param("pagesize") int pagesize,
+						 @Param("username") String username,
+						 @Param("role") int role);
 
-	public XxlJobUser loadByUserName(@Param("username") String username);
+	XxlJobUser loadByUserName(@Param("username") String username);
 
-	public int save(XxlJobUser xxlJobUser);
+	int save(XxlJobUser xxlJobUser);
 
-	public int update(XxlJobUser xxlJobUser);
+	int update(XxlJobUser xxlJobUser);
 	
-	public int delete(@Param("id") int id);
+	int delete(@Param("id") int id);
 
 }

--- a/xxl-job-admin/src/main/resources/logback.xml
+++ b/xxl-job-admin/src/main/resources/logback.xml
@@ -2,7 +2,7 @@
 <configuration debug="false" scan="true" scanPeriod="1 seconds">
 
     <contextName>logback</contextName>
-    <property name="log.path" value="/data/applogs/xxl-job/xxl-job-admin.log"/>
+    <property name="log.path" value="~/logs/xxl-job/xxl-job-admin.log"/>
 
     <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/xxl-job-core/src/main/java/com/xxl/job/core/executor/XxlJobExecutor.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/executor/XxlJobExecutor.java
@@ -124,7 +124,7 @@ public class XxlJobExecutor  {
                     AdminBiz adminBiz = new AdminBizClient(address.trim(), accessToken);
 
                     if (adminBizList == null) {
-                        adminBizList = new ArrayList<AdminBiz>();
+                        adminBizList = new ArrayList<>();
                     }
                     adminBizList.add(adminBiz);
                 }
@@ -173,7 +173,7 @@ public class XxlJobExecutor  {
 
 
     // ---------------------- job handler repository ----------------------
-    private static ConcurrentMap<String, IJobHandler> jobHandlerRepository = new ConcurrentHashMap<String, IJobHandler>();
+    private static final ConcurrentMap<String, IJobHandler> jobHandlerRepository = new ConcurrentHashMap<>();
     public static IJobHandler loadJobHandler(String name){
         return jobHandlerRepository.get(name);
     }
@@ -237,11 +237,11 @@ public class XxlJobExecutor  {
 
 
     // ---------------------- job thread repository ----------------------
-    private static ConcurrentMap<Integer, JobThread> jobThreadRepository = new ConcurrentHashMap<Integer, JobThread>();
+    private static final ConcurrentMap<Integer, JobThread> jobThreadRepository = new ConcurrentHashMap<>();
     public static JobThread registJobThread(int jobId, IJobHandler handler, String removeOldReason){
         JobThread newJobThread = new JobThread(jobId, handler);
         newJobThread.start();
-        logger.info(">>>>>>>>>>> xxl-job regist JobThread success, jobId:{}, handler:{}", new Object[]{jobId, handler});
+        logger.info(">>>>>>>>>>> xxl-job regist JobThread success, jobId:{}, handler:{}", jobId, handler);
 
         JobThread oldJobThread = jobThreadRepository.put(jobId, newJobThread);	// putIfAbsent | oh my god, map's put method return the old value!!!
         if (oldJobThread != null) {
@@ -262,8 +262,7 @@ public class XxlJobExecutor  {
         return null;
     }
     public static JobThread loadJobThread(int jobId){
-        JobThread jobThread = jobThreadRepository.get(jobId);
-        return jobThread;
+        return jobThreadRepository.get(jobId);
     }
 
 }

--- a/xxl-job-executor-samples/xxl-job-executor-sample-springboot/src/main/resources/application.properties
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-springboot/src/main/resources/application.properties
@@ -21,6 +21,6 @@ xxl.job.executor.address=
 xxl.job.executor.ip=
 xxl.job.executor.port=9999
 ### xxl-job executor log-path
-xxl.job.executor.logpath=/data/applogs/xxl-job/jobhandler
+xxl.job.executor.logpath=~/logs/xxl-job/jobhandler
 ### xxl-job executor log-retention-days
 xxl.job.executor.logretentiondays=30

--- a/xxl-job-executor-samples/xxl-job-executor-sample-springboot/src/main/resources/logback.xml
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-springboot/src/main/resources/logback.xml
@@ -2,7 +2,7 @@
 <configuration debug="false" scan="true" scanPeriod="1 seconds">
 
     <contextName>logback</contextName>
-    <property name="log.path" value="/data/applogs/xxl-job/xxl-job-executor-sample-springboot.log"/>
+    <property name="log.path" value="~/logs/xxl-job/xxl-job-executor-sample-springboot.log"/>
 
     <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>


### PR DESCRIPTION
1. POM文件已指定JDK1.8，则JDK1.8返回类型参数不需要显示指定范型
2. 日志error方法如果第二个参数是throwable，第一个字符串参数的变量是无效的
3. 不必要的拆箱，parseInt就可以
4. interface方法默认都是public方法，不需要显式指定，可使代码更简洁
5. 默认日志文件夹改为用户日志则必然存在，减少第一次启动时/data目录不存在时导致启动失败，用户体验会更友好

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**


**Other information:**