### PR TITLE
fix 唯一键冲突

### DIFF
--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/thread/JobLogReportHelper.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/thread/JobLogReportHelper.java
@@ -83,7 +83,11 @@ public class JobLogReportHelper {
                             // do refresh
                             int ret = XxlJobAdminConfig.getAdminConfig().getXxlJobLogReportDao().update(xxlJobLogReport);
                             if (ret < 1) {
-                                XxlJobAdminConfig.getAdminConfig().getXxlJobLogReportDao().save(xxlJobLogReport);
+                                //query if triggerDay exist
+                                int cnt = XxlJobAdminConfig.getAdminConfig().getXxlJobLogReportDao().countLogReport(xxlJobLogReport.getTriggerDay());
+                                if(cnt == 0){
+                                    XxlJobAdminConfig.getAdminConfig().getXxlJobLogReportDao().save(xxlJobLogReport);
+                                }
                             }
                         }
 

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobLogReportDao.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/XxlJobLogReportDao.java
@@ -23,4 +23,5 @@ public interface XxlJobLogReportDao {
 
 	public XxlJobLogReport queryLogReportTotal();
 
+    public int countLogReport(Date triggerDay);
 }

--- a/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobLogReportMapper.xml
+++ b/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobLogReportMapper.xml
@@ -58,5 +58,8 @@
 			SUM(fail_count) fail_count
 		FROM xxl_job_log_report AS t
 	</select>
+	<select id="countLogReport" resultType="java.lang.Integer">
+		select count(*) from xxl_job_log_report where `trigger_day` = #{triggerDay}
+	</select>
 
 </mapper>


### PR DESCRIPTION
提高程序健壮性，
当mysql配置useAffectedRows=true时,再次校验，防止出现唯一键冲突

[link #2682](https://github.com/xuxueli/xxl-job/issues/2682#issue-1059787427)