### PR TITLE
Bugfix：生成callbacklog大量占用堆内存

### DIFF
--- a/xxl-job-core/src/main/java/com/xxl/job/core/thread/TriggerCallbackThread.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/thread/TriggerCallbackThread.java
@@ -243,7 +243,7 @@ public class TriggerCallbackThread {
         }
 
         // load and clear file, retry
-        List<HandleCallbackParam> callbackParamList = new ArrayList<>();
+        List<List<HandleCallbackParam>> callbackParamList = new ArrayList<>();
         do {
             callbackParamList.clear();
             for (File callbaclLogFile: callbackLogPath.listFiles()) {
@@ -254,9 +254,9 @@ public class TriggerCallbackThread {
                     continue;
                 }
 
-                callbackParamList.addAll((List<HandleCallbackParam>) JdkSerializeTool.deserialize(callbackParamList_bytes, List.class));
+                callbackParamList.add((List<HandleCallbackParam>) JdkSerializeTool.deserialize(callbackParamList_bytes, List.class));
             }
-            doCallback(callbackParamList);
+            callbackParamList.forEach( p -> doCallback(p));
         } while (!callbackParamList.isEmpty());
 
     }

--- a/xxl-job-core/src/test/java/TestTriggerCallbackThread.java
+++ b/xxl-job-core/src/test/java/TestTriggerCallbackThread.java
@@ -1,0 +1,66 @@
+import com.xxl.job.core.biz.model.HandleCallbackParam;
+import com.xxl.job.core.executor.XxlJobExecutor;
+import com.xxl.job.core.thread.TriggerCallbackThread;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * @Author: yusy
+ * @Date: 2021/12/23
+ */
+public class TestTriggerCallbackThread {
+
+    public static void main(String[] args) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, NoSuchFieldException, InterruptedException {
+        t1();
+    }
+
+
+    public static void t1() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, NoSuchFieldException, InterruptedException {
+        XxlJobExecutor xxlJobExecutor = new XxlJobExecutor();
+        xxlJobExecutor.setAdminAddresses("http://192.168.0.248:8080/xxl-job-admin");
+
+        Method initAdminBizList = xxlJobExecutor.getClass().getDeclaredMethod("initAdminBizList", String.class, String.class);
+        initAdminBizList.setAccessible(true);
+
+
+        initAdminBizList.invoke(xxlJobExecutor, "http://192.168.0.248:8080/xxl-job-admin", "a");
+
+
+
+
+
+        TriggerCallbackThread instance = TriggerCallbackThread.getInstance();
+
+        for (Field field : TriggerCallbackThread.class.getDeclaredFields()) {
+            if (field.getName().equals("failCallbackFilePath")) {
+                field.setAccessible(true);
+                field.set(null, "d:/tmp/callback/");
+            } else if (field.getName().equals("failCallbackFileName")) {
+                field.setAccessible(true);
+                field.set(null, "d:/tmp/callback/".concat("xxl-job-callback-{x}").concat(".log"));
+            }
+        }
+
+        Method appendFailCallbackFile = instance.getClass().getDeclaredMethod("appendFailCallbackFile", List.class);
+        appendFailCallbackFile.setAccessible(true);
+
+        HandleCallbackParam h = new HandleCallbackParam();
+        h.setLogId(1L);
+        h.setHandleCode(200);
+        h.setHandleMsg("sssss");
+        h.setLogDateTim(System.currentTimeMillis());
+
+
+        appendFailCallbackFile.invoke(instance, Collections.singletonList(h));
+
+
+        instance.start();
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        countDownLatch.await();
+    }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [* ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

BUG背景
admin配置了accessToken而应用未配置accessToken导致doCallback不断失败，不断在循环内生成callbacklog，产生了大量File类无法回收（约8,109,008个），堆占用达到了4G
故修改retryFailCallbackFile逻辑，在完全清除了logfile以后再doCallback

使用的是2.3.0版本