### PR TITLE
调整xxl_job_info表执行参数不限制参数长度

### DIFF
--- a/doc/db/tables_xxl_job.sql
+++ b/doc/db/tables_xxl_job.sql
@@ -20,7 +20,7 @@ CREATE TABLE `xxl_job_info` (
   `misfire_strategy` varchar(50) NOT NULL DEFAULT 'DO_NOTHING' COMMENT '调度过期策略',
   `executor_route_strategy` varchar(50) DEFAULT NULL COMMENT '执行器路由策略',
   `executor_handler` varchar(255) DEFAULT NULL COMMENT '执行器任务handler',
-  `executor_param` varchar(512) DEFAULT NULL COMMENT '执行器任务参数',
+  `executor_param` text DEFAULT NULL COMMENT '执行器任务参数',
   `executor_block_strategy` varchar(50) DEFAULT NULL COMMENT '阻塞处理策略',
   `executor_timeout` int(11) NOT NULL DEFAULT '0' COMMENT '任务执行超时时间，单位秒',
   `executor_fail_retry_count` int(11) NOT NULL DEFAULT '0' COMMENT '失败重试次数',

--- a/xxl-job-admin/src/main/resources/templates/jobinfo/jobinfo.index.ftl
+++ b/xxl-job-admin/src/main/resources/templates/jobinfo/jobinfo.index.ftl
@@ -184,7 +184,7 @@
                     <div class="form-group">
                         <label for="firstname" class="col-sm-2 control-label">${I18n.jobinfo_field_executorparam}<font color="black">*</font></label>
                         <div class="col-sm-10">
-                            <textarea class="textarea form-control" name="executorParam" placeholder="${I18n.system_please_input}${I18n.jobinfo_field_executorparam}" maxlength="512" style="height: 63px; line-height: 1.2;"></textarea>
+                            <textarea class="textarea form-control" name="executorParam" placeholder="${I18n.system_please_input}${I18n.jobinfo_field_executorparam}" style="height: 63px; line-height: 1.2;"></textarea>
                         </div>
                     </div>
 

--- a/xxl-job-admin/src/main/resources/templates/jobinfo/jobinfo.index.ftl
+++ b/xxl-job-admin/src/main/resources/templates/jobinfo/jobinfo.index.ftl
@@ -429,7 +429,7 @@ exit 0
                     <div class="form-group">
                         <label for="firstname" class="col-sm-2 control-label">${I18n.jobinfo_field_executorparam}<font color="black">*</font></label>
                         <div class="col-sm-10">
-                            <textarea class="textarea form-control" name="executorParam" placeholder="${I18n.system_please_input}${I18n.jobinfo_field_executorparam}" maxlength="512" style="height: 63px; line-height: 1.2;"></textarea>
+                            <textarea class="textarea form-control" name="executorParam" placeholder="${I18n.system_please_input}${I18n.jobinfo_field_executorparam}" style="height: 63px; line-height: 1.2;"></textarea>
                         </div>
                     </div>
 
@@ -504,7 +504,7 @@ exit 0
                     <div class="form-group">
                         <label for="firstname" class="col-sm-2 control-label">${I18n.jobinfo_field_executorparam}<font color="black">*</font></label>
                         <div class="col-sm-10">
-                            <textarea class="textarea form-control" name="executorParam" placeholder="${I18n.system_please_input}${I18n.jobinfo_field_executorparam}" maxlength="512" style="height: 63px; line-height: 1.2;"></textarea>
+                            <textarea class="textarea form-control" name="executorParam" placeholder="${I18n.system_please_input}${I18n.jobinfo_field_executorparam}" style="height: 63px; line-height: 1.2;"></textarea>
                         </div>
                     </div>
                     <div class="form-group">


### PR DESCRIPTION
在我们生产环境，发现执行参数动态添加时仅支持长度varchar(512)，并满足不了我们的需求，因此将表结构从varchar(512)调整为text，来支持我们的动态参数