### PR TITLE
support k8s deployed app log query

### DIFF
--- a/xxl-job-admin/src/main/resources/i18n/message_en.properties
+++ b/xxl-job-admin/src/main/resources/i18n/message_en.properties
@@ -197,6 +197,7 @@ joblog_rolling_log_failoften=The request for the Rolling log is terminated, the 
 joblog_logid_unvalid=Log ID is illegal
 
 ## job group
+jobgroup_id_unvalid=Executor ID is illegal
 jobgroup_name=Executor Manage
 jobgroup_list=Executor List
 jobgroup_add=Add Executor

--- a/xxl-job-admin/src/main/resources/i18n/message_zh_CN.properties
+++ b/xxl-job-admin/src/main/resources/i18n/message_zh_CN.properties
@@ -197,6 +197,7 @@ joblog_rolling_log_failoften=终止请求Rolling日志,请求失败次数超上�
 joblog_logid_unvalid=日志ID非法
 
 ## job group
+jobgroup_id_unvalid=执行器ID非法
 jobgroup_name=执行器管理
 jobgroup_list=执行器列表
 jobgroup_add=新增执行器

--- a/xxl-job-admin/src/main/resources/i18n/message_zh_TC.properties
+++ b/xxl-job-admin/src/main/resources/i18n/message_zh_TC.properties
@@ -197,6 +197,7 @@ joblog_rolling_log_failoften=終止請求Rolling日誌，請求失敗次數超�
 joblog_logid_unvalid=日誌ID非法
 
 ## job group
+jobgroup_id_unvalid=執行器ID非法
 jobgroup_name=執行器管理
 jobgroup_list=執行器列表
 jobgroup_add=新增執行器

--- a/xxl-job-admin/src/main/resources/static/js/joblog.detail.1.js
+++ b/xxl-job-admin/src/main/resources/static/js/joblog.detail.1.js
@@ -25,7 +25,7 @@ $(function() {
             async: false,   // sync, make log ordered
             url : base_url + '/joblog/logDetailCat',
             data : {
-                "executorAddress":executorAddress,
+                "jobGroupId": jobGroupId,
                 "triggerTime":triggerTime,
                 "logId":logId,
                 "fromLineNum":fromLineNum

--- a/xxl-job-admin/src/main/resources/templates/joblog/joblog.detail.ftl
+++ b/xxl-job-admin/src/main/resources/templates/joblog/joblog.detail.ftl
@@ -65,6 +65,7 @@
     var executorAddress = '${executorAddress!}';
     var triggerTime = '${triggerTime?c}';
     var logId = '${logId}';
+    var jobGroupId = '${jobGroupId}';
 </script>
 <script src="${request.contextPath}/static/js/joblog.detail.1.js"></script>
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature


**The description of the PR:**
`xxljob` 使用 `k8s` 部署时，执行器的 `ip` 地址变更后，无法再查询到历史的执行日志。
排查后发现 `xxljob` 将当时执行 `job` 的执行器地址写入到了执行日志表记录里，这样当执行器 `ip` 发生变更时，将无法再查询到历史日志信息。

<img width="892" alt="image" src="https://user-images.githubusercontent.com/26264096/153127786-642b3bae-f0e6-4b7a-b9aa-c396f85163a2.png">

<img width="1437" alt="image" src="https://user-images.githubusercontent.com/26264096/153127595-92ed957e-1a0a-4e94-929a-b57acc388ac7.png">

**Other information:**