### PR TITLE
maven依赖管理引入 spring-boot-dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,20 +24,8 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.test.skip>true</maven.test.skip>
 
-		<netty-all.version>4.1.58.Final</netty-all.version>
-		<gson.version>2.8.6</gson.version>
-
-		<spring.version>5.3.3</spring.version>
 		<spring-boot.version>2.4.2</spring-boot.version>
-
 		<mybatis-spring-boot-starter.version>2.1.4</mybatis-spring-boot-starter.version>
-		<mysql-connector-java.version>8.0.23</mysql-connector-java.version>
-
-		<slf4j-api.version>1.7.30</slf4j-api.version>
-		<junit.version>5.7.1</junit.version>
-		<javax.annotation-api.version>1.3.2</javax.annotation-api.version>
-
-		<groovy.version>3.0.7</groovy.version>
 
 		<maven-source-plugin.version>3.2.1</maven-source-plugin.version>
 		<maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
@@ -45,9 +33,44 @@
 		<maven-war-plugin.version>3.3.1</maven-war-plugin.version>
 	</properties>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-dependencies</artifactId>
+				<version>${spring-boot.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>com.xuxueli</groupId>
+				<artifactId>xxl-job-core</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.mybatis.spring.boot</groupId>
+				<artifactId>mybatis-spring-boot-starter</artifactId>
+				<version>${mybatis-spring-boot-starter.version}</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<build>
-		<plugins>
-		</plugins>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-maven-plugin</artifactId>
+					<version>${spring-boot.version}</version>
+				</plugin>
+				<!-- docker -->
+				<plugin>
+					<groupId>com.spotify</groupId>
+					<artifactId>docker-maven-plugin</artifactId>
+					<version>0.4.13</version>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 	</build>
 
 

--- a/xxl-job-admin/pom.xml
+++ b/xxl-job-admin/pom.xml
@@ -9,18 +9,6 @@
 	<artifactId>xxl-job-admin</artifactId>
 	<packaging>jar</packaging>
 
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-starter-parent</artifactId>
-				<version>${spring-boot.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
-
 	<dependencies>
 
 		<!-- starter-web：spring-webmvc + autoconfigure + logback + yaml + tomcat -->
@@ -57,20 +45,17 @@
 		<dependency>
 			<groupId>org.mybatis.spring.boot</groupId>
 			<artifactId>mybatis-spring-boot-starter</artifactId>
-			<version>${mybatis-spring-boot-starter.version}</version>
 		</dependency>
 		<!-- mysql -->
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>${mysql-connector-java.version}</version>
 		</dependency>
 
 		<!-- xxl-job-core -->
 		<dependency>
 			<groupId>com.xuxueli</groupId>
 			<artifactId>xxl-job-core</artifactId>
-			<version>${project.parent.version}</version>
 		</dependency>
 
 	</dependencies>
@@ -80,7 +65,6 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				<version>${spring-boot.version}</version>
 				<executions>
 					<execution>
 						<goals>
@@ -93,7 +77,6 @@
 			<plugin>
 				<groupId>com.spotify</groupId>
 				<artifactId>docker-maven-plugin</artifactId>
-				<version>0.4.13</version>
 				<configuration>
 					<!-- made of '[a-z0-9-_.]' -->
 					<imageName>${project.artifactId}:${project.version}</imageName>

--- a/xxl-job-core/pom.xml
+++ b/xxl-job-core/pom.xml
@@ -19,12 +19,10 @@
 		<dependency>
 			<groupId>io.netty</groupId>
 			<artifactId>netty-all</artifactId>
-			<version>${netty-all.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>${gson.version}</version>
 		</dependency>
 
 		<!-- ********************** plugin ********************** -->
@@ -32,14 +30,12 @@
 		<dependency>
 			<groupId>org.codehaus.groovy</groupId>
 			<artifactId>groovy</artifactId>
-			<version>${groovy.version}</version>
 		</dependency>
 
 		<!-- spring-context -->
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>${spring.version}</version>
 			<scope>provided</scope>
 		</dependency>
 
@@ -48,14 +44,12 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>${slf4j-api.version}</version>
 		</dependency>
 
 		<!-- javax.annotation-api -->
 		<dependency>
 			<groupId>javax.annotation</groupId>
 			<artifactId>javax.annotation-api</artifactId>
-			<version>${javax.annotation-api.version}</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/xxl-job-executor-samples/xxl-job-executor-sample-frameless/pom.xml
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-frameless/pom.xml
@@ -22,13 +22,11 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>${slf4j-api.version}</version>
         </dependency>
         <!-- junit -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -36,7 +34,6 @@
         <dependency>
             <groupId>com.xuxueli</groupId>
             <artifactId>xxl-job-core</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
 
     </dependencies>

--- a/xxl-job-executor-samples/xxl-job-executor-sample-springboot/pom.xml
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-springboot/pom.xml
@@ -18,19 +18,6 @@
     <properties>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <!-- Import dependency management from Spring Boot (依赖管理：继承一些默认的依赖，工程需要依赖的jar包的管理，申明其他dependency的时候就不需要version) -->
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-starter-parent</artifactId>
-                <version>${spring-boot.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <!-- spring-boot-starter-web (spring-webmvc + tomcat) -->
         <dependency>
@@ -47,7 +34,6 @@
         <dependency>
             <groupId>com.xuxueli</groupId>
             <artifactId>xxl-job-core</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
 
     </dependencies>
@@ -58,7 +44,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring-boot.version}</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
**借助 spring-boot-dependencies 规范化全工程的依赖包版本**

- [x] Build-related changes
规范化全工程的依赖包版本

**The description of the PR:**
善用 dependencyManagement 在 parent-pom 定义全工程的依赖包版本.
直接导入 spring-boot-dependencies 的版本定义, 子工程无需再写依赖包的 version.
依赖包兼容性有 spring 社区背书, 以免自己拼凑而产生冲突与兼容问题
今后升级 spring-boot 版本, 直接更新 spring-boot-dependencies 的版本即可
