### PR TITLE
interrupt a task without stopping the JobThread

### DIFF
--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/controller/JobInfoController.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/controller/JobInfoController.java
@@ -130,6 +130,12 @@ public class JobInfoController {
 	public ReturnT<String> pause(int id) {
 		return xxlJobService.stop(id);
 	}
+
+	@RequestMapping("/interrupt")
+	@ResponseBody
+	public ReturnT<String> interrupt(int id) {
+		return xxlJobService.interrupt(id);
+	}
 	
 	@RequestMapping("/start")
 	@ResponseBody

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/service/XxlJobService.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/service/XxlJobService.java
@@ -83,4 +83,10 @@ public interface XxlJobService {
 	 */
 	public ReturnT<Map<String,Object>> chartInfo(Date startDate, Date endDate);
 
+	/**
+	 * interrupt info
+	 * @param id
+	 * @return
+	 */
+    ReturnT<String> interrupt(int id);
 }

--- a/xxl-job-admin/src/main/resources/i18n/message_en.properties
+++ b/xxl-job-admin/src/main/resources/i18n/message_en.properties
@@ -130,6 +130,7 @@ jobinfo_script_location=Script location
 jobinfo_shard_index=Shard index
 jobinfo_shard_total=Shard total
 jobinfo_opt_stop=Stop
+jobinfo_opt_interrupt=Interrupt current schedule
 jobinfo_opt_start=Start
 jobinfo_opt_log=Query Log
 jobinfo_opt_run=Run Once

--- a/xxl-job-admin/src/main/resources/i18n/message_zh_CN.properties
+++ b/xxl-job-admin/src/main/resources/i18n/message_zh_CN.properties
@@ -130,6 +130,7 @@ jobinfo_script_location=脚本位置
 jobinfo_shard_index=分片序号
 jobinfo_shard_total=分片总数
 jobinfo_opt_stop=停止
+jobinfo_opt_interrupt=中断当前调度
 jobinfo_opt_start=启动
 jobinfo_opt_log=查询日志
 jobinfo_opt_run=执行一次

--- a/xxl-job-admin/src/main/resources/i18n/message_zh_TC.properties
+++ b/xxl-job-admin/src/main/resources/i18n/message_zh_TC.properties
@@ -130,6 +130,7 @@ jobinfo_script_location=腳本位置
 jobinfo_shard_index=分片序號
 jobinfo_shard_total=分片總數
 jobinfo_opt_stop=停止
+jobinfo_opt_interrupt=中斷當前調度
 jobinfo_opt_start=啟動
 jobinfo_opt_log=查詢日誌
 jobinfo_opt_run=執行一次

--- a/xxl-job-admin/src/main/resources/static/js/jobinfo.index.1.js
+++ b/xxl-job-admin/src/main/resources/static/js/jobinfo.index.1.js
@@ -117,6 +117,7 @@ $(function() {
                                 } else {
                                     start_stop_div = '<li><a href="javascript:void(0);" class="job_operate" _type="job_resume" >'+ I18n.jobinfo_opt_start +'</a></li>\n';
                                 }
+								start_stop_div += '<li><a href="javascript:void(0);" class="job_operate" _type="job_interrupt" >'+ I18n.jobinfo_opt_interrupt +'</a></li>\n';
 
                                 // job_next_time_html
 								var job_next_time_html = '';
@@ -223,6 +224,10 @@ $(function() {
 		} else if ("job_del" == type) {
 			typeName = I18n.system_opt_del ;
 			url = base_url + "/jobinfo/remove";
+			needFresh = true;
+		} else if ("job_interrupt" == type) {
+			typeName = I18n.jobinfo_opt_interrupt ;
+			url = base_url + "/jobinfo/interrupt";
 			needFresh = true;
 		} else {
 			return;

--- a/xxl-job-core/src/main/java/com/xxl/job/core/biz/ExecutorBiz.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/biz/ExecutorBiz.java
@@ -34,7 +34,12 @@ public interface ExecutorBiz {
      * @return
      */
     public ReturnT<String> kill(KillParam killParam);
-
+    /**
+     * interrupt
+     * @param interruptParam
+     * @return
+     */
+    public ReturnT<String> interrupt(InterruptParam interruptParam);
     /**
      * log
      * @param logParam

--- a/xxl-job-core/src/main/java/com/xxl/job/core/biz/client/ExecutorBizClient.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/biz/client/ExecutorBizClient.java
@@ -49,6 +49,11 @@ public class ExecutorBizClient implements ExecutorBiz {
     }
 
     @Override
+    public ReturnT<String> interrupt(InterruptParam interruptParam) {
+        return XxlJobRemotingUtil.postBody(addressUrl + "interrupt", accessToken, timeout, interruptParam, String.class);
+    }
+
+    @Override
     public ReturnT<LogResult> log(LogParam logParam) {
         return XxlJobRemotingUtil.postBody(addressUrl + "log", accessToken, timeout, logParam, LogResult.class);
     }

--- a/xxl-job-core/src/main/java/com/xxl/job/core/biz/impl/ExecutorBizImpl.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/biz/impl/ExecutorBizImpl.java
@@ -161,6 +161,16 @@ public class ExecutorBizImpl implements ExecutorBiz {
     }
 
     @Override
+    public ReturnT<String> interrupt(InterruptParam interruptParam) {
+        JobThread jobThread = XxlJobExecutor.loadJobThread(interruptParam.getJobId());
+        if (jobThread != null) {
+            XxlJobExecutor.abortRunningTask(interruptParam.getJobId());
+            return ReturnT.SUCCESS;
+        }
+        return new ReturnT<String>(ReturnT.SUCCESS_CODE, "job thread already interrupted.");
+    }
+
+    @Override
     public ReturnT<LogResult> log(LogParam logParam) {
         // log filename: logPath/yyyy-MM-dd/9999.log
         String logFileName = XxlJobFileAppender.makeLogFileName(new Date(logParam.getLogDateTim()), logParam.getLogId());

--- a/xxl-job-core/src/main/java/com/xxl/job/core/biz/model/InterruptParam.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/biz/model/InterruptParam.java
@@ -1,0 +1,29 @@
+package com.xxl.job.core.biz.model;
+
+import java.io.Serializable;
+
+/**
+ * @author cszxyang
+ * @date 2022-04-20
+ */
+public class InterruptParam implements Serializable {
+    private static final long serialVersionUID = 42L;
+
+    public InterruptParam() {
+    }
+    public InterruptParam(int jobId) {
+        this.jobId = jobId;
+    }
+
+    private int jobId;
+
+
+    public int getJobId() {
+        return jobId;
+    }
+
+    public void setJobId(int jobId) {
+        this.jobId = jobId;
+    }
+
+}

--- a/xxl-job-core/src/main/java/com/xxl/job/core/executor/XxlJobExecutor.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/executor/XxlJobExecutor.java
@@ -261,6 +261,16 @@ public class XxlJobExecutor  {
         }
         return null;
     }
+
+    public static void abortRunningTask(int jobId) {
+        JobThread jobThread = jobThreadRepository.get(jobId);
+        try {
+            jobThread.abortRunning();
+        } catch (Exception e) {
+            logger.error("exception occurs while aborting running task, ", e);
+        }
+    }
+
     public static JobThread loadJobThread(int jobId){
         JobThread jobThread = jobThreadRepository.get(jobId);
         return jobThread;

--- a/xxl-job-core/src/main/java/com/xxl/job/core/server/EmbedServer.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/server/EmbedServer.java
@@ -205,6 +205,9 @@ public class EmbedServer {
                 } else if ("/log".equals(uri)) {
                     LogParam logParam = GsonTool.fromJson(requestData, LogParam.class);
                     return executorBiz.log(logParam);
+                } else if ("/interrupt".equals(uri)) {
+                    InterruptParam interruptParam = GsonTool.fromJson(requestData, InterruptParam.class);
+                    return executorBiz.interrupt(interruptParam);
                 } else {
                     return new ReturnT<String>(ReturnT.FAIL_CODE, "invalid request, uri-mapping("+ uri +") not found.");
                 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**The description of the PR:**

The current "stop" function for JobInfo does not interrupt the currently scheduled task, as the actual project needs to interrupt the running task, so this option is added, but for the thread in the running state, there is no good way to interrupt it, so still use the Thread.interrupt(0 method.

![94b0fd4de6d8ffbbcf97363be86fc26](https://user-images.githubusercontent.com/50173065/164482360-23681fdf-0695-4c50-89a8-29c2924cf1e7.png)


**Other information:**

The JobThread.run method is too long. In this commit, the place where a single task is executed is extracted into a doTrigger method.