### PR TITLE
针对分片广播，增加一个时间戳来区分不同批次的分片任务

### DIFF
--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/trigger/XxlJobTrigger.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/trigger/XxlJobTrigger.java
@@ -54,6 +54,7 @@ public class XxlJobTrigger {
             logger.warn(">>>>>>>>>>>> trigger fail, jobId invalid，jobId={}", jobId);
             return;
         }
+        long nowTime = (new Date()).getTime();
         if (executorParam != null) {
             jobInfo.setExecutorParam(executorParam);
         }
@@ -80,13 +81,13 @@ public class XxlJobTrigger {
                 && group.getRegistryList()!=null && !group.getRegistryList().isEmpty()
                 && shardingParam==null) {
             for (int i = 0; i < group.getRegistryList().size(); i++) {
-                processTrigger(group, jobInfo, finalFailRetryCount, triggerType, i, group.getRegistryList().size());
+                processTrigger(group, jobInfo, finalFailRetryCount, triggerType, i, group.getRegistryList().size(),nowTime);
             }
         } else {
             if (shardingParam == null) {
                 shardingParam = new int[]{0, 1};
             }
-            processTrigger(group, jobInfo, finalFailRetryCount, triggerType, shardingParam[0], shardingParam[1]);
+            processTrigger(group, jobInfo, finalFailRetryCount, triggerType, shardingParam[0], shardingParam[1],nowTime);
         }
 
     }
@@ -108,7 +109,7 @@ public class XxlJobTrigger {
      * @param index                     sharding index
      * @param total                     sharding index
      */
-    private static void processTrigger(XxlJobGroup group, XxlJobInfo jobInfo, int finalFailRetryCount, TriggerTypeEnum triggerType, int index, int total){
+    private static void processTrigger(XxlJobGroup group, XxlJobInfo jobInfo, int finalFailRetryCount, TriggerTypeEnum triggerType, int index, int total,long nowTime){
 
         // param
         ExecutorBlockStrategyEnum blockStrategy = ExecutorBlockStrategyEnum.match(jobInfo.getExecutorBlockStrategy(), ExecutorBlockStrategyEnum.SERIAL_EXECUTION);  // block strategy
@@ -137,7 +138,8 @@ public class XxlJobTrigger {
         triggerParam.setGlueUpdatetime(jobInfo.getGlueUpdatetime().getTime());
         triggerParam.setBroadcastIndex(index);
         triggerParam.setBroadcastTotal(total);
-
+        //add timestamp
+        triggerParam.setTimestamp(nowTime);
         // 3、init address
         String address = null;
         ReturnT<String> routeAddressResult = null;

--- a/xxl-job-core/src/main/java/com/xxl/job/core/biz/model/TriggerParam.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/biz/model/TriggerParam.java
@@ -24,7 +24,8 @@ public class TriggerParam implements Serializable{
 
     private int broadcastIndex;
     private int broadcastTotal;
-
+    //new add
+    private long timestamp;
 
     public int getJobId() {
         return jobId;
@@ -122,6 +123,13 @@ public class TriggerParam implements Serializable{
         this.broadcastTotal = broadcastTotal;
     }
 
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
 
     @Override
     public String toString() {
@@ -138,6 +146,7 @@ public class TriggerParam implements Serializable{
                 ", glueUpdatetime=" + glueUpdatetime +
                 ", broadcastIndex=" + broadcastIndex +
                 ", broadcastTotal=" + broadcastTotal +
+                ", timestamp=" + timestamp +
                 '}';
     }
 

--- a/xxl-job-core/src/main/java/com/xxl/job/core/context/XxlJobContext.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/context/XxlJobContext.java
@@ -60,13 +60,18 @@ public class XxlJobContext {
      */
     private String handleMsg;
 
+    /**
+     * new add timestamp
+     */
+    private long timestamp;
 
-    public XxlJobContext(long jobId, String jobParam, String jobLogFileName, int shardIndex, int shardTotal) {
+    public XxlJobContext(long jobId, String jobParam, String jobLogFileName, int shardIndex, int shardTotal,long timestamp) {
         this.jobId = jobId;
         this.jobParam = jobParam;
         this.jobLogFileName = jobLogFileName;
         this.shardIndex = shardIndex;
         this.shardTotal = shardTotal;
+        this.timestamp = timestamp;
 
         this.handleCode = HANDLE_CODE_SUCCESS;  // default success
     }
@@ -106,7 +111,13 @@ public class XxlJobContext {
     public String getHandleMsg() {
         return handleMsg;
     }
+    public long getTimestamp() {
+        return timestamp;
+    }
 
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
     // ---------------------- tool ----------------------
 
     private static InheritableThreadLocal<XxlJobContext> contextHolder = new InheritableThreadLocal<XxlJobContext>(); // support for child thread of job handler)

--- a/xxl-job-core/src/main/java/com/xxl/job/core/context/XxlJobHelper.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/context/XxlJobHelper.java
@@ -94,6 +94,20 @@ public class XxlJobHelper {
         return xxlJobContext.getShardTotal();
     }
 
+
+    /**
+     * current batch jobid  timestamp
+     *
+     * @return
+     */
+    public static long getJobTimeStamp() {
+        XxlJobContext xxlJobContext = XxlJobContext.getXxlJobContext();
+        if (xxlJobContext == null) {
+            return -1;
+        }
+
+        return xxlJobContext.getTimestamp();
+    }
     // ---------------------- tool for log ----------------------
 
     private static Logger logger = LoggerFactory.getLogger("xxl-job logger");

--- a/xxl-job-core/src/main/java/com/xxl/job/core/thread/JobThread.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/thread/JobThread.java
@@ -124,7 +124,8 @@ public class JobThread extends Thread{
 							triggerParam.getExecutorParams(),
 							logFileName,
 							triggerParam.getBroadcastIndex(),
-							triggerParam.getBroadcastTotal());
+							triggerParam.getBroadcastTotal(),
+							triggerParam.getTimestamp());
 
 					// init job context
 					XxlJobContext.setXxlJobContext(xxlJobContext);

--- a/xxl-job-core/src/main/java/com/xxl/job/core/thread/TriggerCallbackThread.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/thread/TriggerCallbackThread.java
@@ -193,6 +193,7 @@ public class TriggerCallbackThread {
                     null,
                     logFileName,
                     -1,
+                    -1,
                     -1));
             XxlJobHelper.log(logContent);
         }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [✓ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**
 主要是针对于分片广播策略。我们有这么一个需求【 在分片广播中，我们需要保证同一批次广播的所有定时任务全部执行完成，才允许执行下一批次定时任务】所以我在定时任务中发送请求中加入了一个时间戳，保证在分片广播中这一批次的任务都有一个相同的时间戳标记，能和上一批广播任务或者下一批广播任务做区别。（时间戳相同表示在分片广播中是同一批次任务）因为在一个任务中无法用参数做区分（参数不管哪一批次都一样）。

**Other information:**