### PR TITLE
chore: Add JobDesc field in `run-once dialog panel`

### DIFF
--- a/xxl-job-admin/src/main/resources/static/js/jobinfo.index.1.js
+++ b/xxl-job-admin/src/main/resources/static/js/jobinfo.index.1.js
@@ -265,6 +265,7 @@ $(function() {
         var row = tableData['key'+id];
 
         $("#jobTriggerModal .form input[name='id']").val( row.id );
+        $("#jobTriggerModal .form textarea[name='jobDesc']").val( row.jobDesc );
         $("#jobTriggerModal .form textarea[name='executorParam']").val( row.executorParam );
 
         $('#jobTriggerModal').modal({backdrop: false, keyboard: false}).modal('show');

--- a/xxl-job-admin/src/main/resources/templates/jobinfo/jobinfo.index.ftl
+++ b/xxl-job-admin/src/main/resources/templates/jobinfo/jobinfo.index.ftl
@@ -502,6 +502,12 @@ exit 0
             <div class="modal-body">
                 <form class="form-horizontal form" role="form" >
                     <div class="form-group">
+                        <label for="firstname" class="col-sm-2 control-label">${I18n.jobinfo_field_jobdesc}</label>
+                        <div class="col-sm-10">
+                            <textarea readonly class="textarea form-control" name="jobDesc" maxlength="512" style="height: 30px; line-height: 1.2;"></textarea>
+                        </div>
+                    </div>
+                    <div class="form-group">
                         <label for="firstname" class="col-sm-2 control-label">${I18n.jobinfo_field_executorparam}<font color="black">*</font></label>
                         <div class="col-sm-10">
                             <textarea class="textarea form-control" name="executorParam" placeholder="${I18n.system_please_input}${I18n.jobinfo_field_executorparam}" maxlength="512" style="height: 63px; line-height: 1.2;"></textarea>
@@ -516,7 +522,7 @@ exit 0
                     <hr>
                     <div class="form-group">
                         <div class="col-sm-offset-3 col-sm-6">
-                            <button type="button" class="btn btn-primary ok" >${I18n.system_save}</button>
+                            <button type="button" class="btn btn-primary ok" >${I18n.system_ok}</button>
                             <button type="button" class="btn btn-default" data-dismiss="modal">${I18n.system_cancel}</button>
                             <input type="hidden" name="id" >
                         </div>


### PR DESCRIPTION
- 避免使用者在 RunOnce 階段操作時，失誤點到錯誤的任務並執行，建議在此階段將 JobDescription 也呈現，供再次確認使用
- 調整 Button 文案，改為使用 system_ok 更加符合此行為語意

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**


**Other information:**