### PR TITLE
移除默认添加的management.server.servlet.context-path=/actuator  配置，该配置会导致实际访…

### DIFF
--- a/xxl-job-admin/src/main/resources/application.properties
+++ b/xxl-job-admin/src/main/resources/application.properties
@@ -3,7 +3,6 @@ server.port=8080
 server.servlet.context-path=/xxl-job-admin
 
 ### actuator
-management.server.servlet.context-path=/actuator
 management.health.mail.enabled=false
 
 ### resources


### PR DESCRIPTION
…问actuator 相关接口的路由变为 /actuator/actuator

如题， 移除默认添加的management.server.servlet.context-path=/actuator  配置，该配置会导致实际访问actuator 相关接口的路由变为 /actuator/actuator， 使用/actuator 进行访问时，会得到404 的响应，对不熟悉management配置的开发者会造成困扰

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**


**Other information:**