### PR TITLE
调度中心-调度日志查询模块 重新打开时间范围下拉框时, 重置下拉框内的时间

### DIFF
--- a/xxl-job-admin/src/main/resources/static/js/joblog.index.1.js
+++ b/xxl-job-admin/src/main/resources/static/js/joblog.index.1.js
@@ -34,15 +34,20 @@ $(function() {
         $("#jobGroup").change();
 	}
 
-	// filter Time
-    var rangesConf = {};
-    rangesConf[I18n.daterangepicker_ranges_recent_hour] = [moment().subtract(1, 'hours'), moment()];
-    rangesConf[I18n.daterangepicker_ranges_today] = [moment().startOf('day'), moment().endOf('day')];
-    rangesConf[I18n.daterangepicker_ranges_yesterday] = [moment().subtract(1, 'days').startOf('day'), moment().subtract(1, 'days').endOf('day')];
-    rangesConf[I18n.daterangepicker_ranges_this_month] = [moment().startOf('month'), moment().endOf('month')];
-    rangesConf[I18n.daterangepicker_ranges_last_month] = [moment().subtract(1, 'months').startOf('month'), moment().subtract(1, 'months').endOf('month')];
-    rangesConf[I18n.daterangepicker_ranges_recent_week] = [moment().subtract(1, 'weeks').startOf('day'), moment().endOf('day')];
-    rangesConf[I18n.daterangepicker_ranges_recent_month] = [moment().subtract(1, 'months').startOf('day'), moment().endOf('day')];
+	function buildRangesConf() {
+		// filter Time
+		var rangesConf = {};
+		rangesConf[I18n.daterangepicker_ranges_recent_hour] = [moment().subtract(1, 'hours'), moment()];
+		rangesConf[I18n.daterangepicker_ranges_today] = [moment().startOf('day'), moment().endOf('day')];
+		rangesConf[I18n.daterangepicker_ranges_yesterday] = [moment().subtract(1, 'days').startOf('day'), moment().subtract(1, 'days').endOf('day')];
+		rangesConf[I18n.daterangepicker_ranges_this_month] = [moment().startOf('month'), moment().endOf('month')];
+		rangesConf[I18n.daterangepicker_ranges_last_month] = [moment().subtract(1, 'months').startOf('month'), moment().subtract(1, 'months').endOf('month')];
+		rangesConf[I18n.daterangepicker_ranges_recent_week] = [moment().subtract(1, 'weeks').startOf('day'), moment().endOf('day')];
+		rangesConf[I18n.daterangepicker_ranges_recent_month] = [moment().subtract(1, 'months').startOf('day'), moment().endOf('day')];
+		return rangesConf;
+	}
+
+	var rangesConf = buildRangesConf();
 
 	$('#filterTime').daterangepicker({
         autoApply:false,
@@ -67,6 +72,11 @@ $(function() {
         },
         startDate: rangesConf[I18n.daterangepicker_ranges_today][0],
         endDate: rangesConf[I18n.daterangepicker_ranges_today][1]
+	});
+
+	$('#filterTime').on('show.daterangepicker', function(ev, picker) {
+		// reset daterangepicker rangesConf
+		picker.ranges = buildRangesConf();
 	});
 
 	// init date tables


### PR DESCRIPTION
重新打开时间范围下拉框时, 重置下拉框内的时间

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**

之前的时间范围选择下拉框内的时间范围是在页面加载时设置的, 不会动态变化

如果在页面停留较久时, 需要刷新页面, 下拉框内的时间范围才会进行更新

所以, 此pr更改了此段逻辑

在重新打开时间范围下拉框时, 重置下拉框内的时间


**Other information:**