### PR TITLE
将mybatis更换为jpa，实现全数据库支持

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
 		<spring-boot.version>2.6.7</spring-boot.version>
 
 		<mybatis-spring-boot-starter.version>2.2.2</mybatis-spring-boot-starter.version>
+		<mybatis.version>3.5.9</mybatis.version>
 		<mysql-connector-java.version>8.0.29</mysql-connector-java.version>
 
 		<slf4j-api.version>1.7.36</slf4j-api.version>

--- a/xxl-job-admin/pom.xml
+++ b/xxl-job-admin/pom.xml
@@ -53,12 +53,23 @@
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 
-		<!-- mybatis-starter：mybatis + mybatis-spring + hikari（default） -->
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+
+		<!-- mybatis-starter：mybatis + mybatis-spring + hikari（default） -->
+		<!-- <dependency>
 			<groupId>org.mybatis.spring.boot</groupId>
 			<artifactId>mybatis-spring-boot-starter</artifactId>
 			<version>${mybatis-spring-boot-starter.version}</version>
+		</dependency> -->
+		<dependency>
+			<groupId>org.mybatis</groupId>
+			<artifactId>mybatis</artifactId>
+			<version>${mybatis.version}</version>
 		</dependency>
+
 		<!-- mysql -->
 		<dependency>
 			<groupId>mysql</groupId>
@@ -71,6 +82,17 @@
 			<groupId>com.xuxueli</groupId>
 			<artifactId>xxl-job-core</artifactId>
 			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.querydsl</groupId>
+			<artifactId>querydsl-apt</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.querydsl</groupId>
+			<artifactId>querydsl-jpa</artifactId>
 		</dependency>
 
 	</dependencies>
@@ -86,6 +108,27 @@
 						<goals>
 							<goal>repackage</goal>
 						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>com.mysema.maven</groupId>
+				<artifactId>apt-maven-plugin</artifactId>
+				<version>1.1.3</version>
+				<executions>
+					<execution>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>process</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>target/generated-sources</outputDirectory>
+							<processor>com.querydsl.apt.jpa.JPAAnnotationProcessor</processor>
+							<options>
+								<querydsl.generatedAnnotationClass>com.querydsl.core.annotations.Generated</querydsl.generatedAnnotationClass>
+							</options>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/XxlJobApplicationRunner.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/XxlJobApplicationRunner.java
@@ -1,0 +1,32 @@
+package com.xxl.job.admin;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+import com.xxl.job.admin.core.util.EntityUtil;
+import com.xxl.job.admin.service.SystemService;
+
+/**
+ * 
+ * @author spenggch
+ *
+ */
+@Component
+public class XxlJobApplicationRunner implements ApplicationRunner {
+
+	@Autowired
+	SystemService systemService;
+
+	@Value("${xxl.job.table.prefix:}")
+	String xxlJobTablePrefix;
+
+	@Override
+	public void run(ApplicationArguments args) throws Exception {
+		EntityUtil.setTablePrefix(xxlJobTablePrefix);
+		systemService.initializeData();
+	}
+
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/controller/JobCodeController.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/controller/JobCodeController.java
@@ -47,7 +47,11 @@ public class JobCodeController {
 
 		// Glue类型-字典
 		model.addAttribute("GlueTypeEnum", GlueTypeEnum.values());
-
+		
+		// 增加判断，解决二次编辑时前端异常的问题（部分数据库会将0长字符串值为null）
+		if (jobInfo.getGlueSource() == null) {
+			jobInfo.setGlueSource("");
+		}
 		model.addAttribute("jobInfo", jobInfo);
 		model.addAttribute("jobLogGlues", jobLogGlues);
 		return "jobcode/jobcode.index";

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobGroup.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobGroup.java
@@ -5,19 +5,53 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import javax.persistence.Transient;
+
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.Comment;
+import org.hibernate.annotations.GenericGenerator;
+
 /**
  * Created by xuxueli on 16/9/30.
  */
+@Entity
+@Table(name = "xxl_job_group")
 public class XxlJobGroup {
 
-    private int id;
-    private String appname;
-    private String title;
-    private int addressType;        // 执行器地址类型：0=自动注册、1=手动录入
-    private String addressList;     // 执行器地址列表，多地址逗号分隔(手动录入)
-    private Date updateTime;
+	@Id
+	@GeneratedValue(generator = "generator")
+	@GenericGenerator(name = "generator", strategy = "native", parameters = {
+			@org.hibernate.annotations.Parameter(name = "sequence_name", value = "s_xxl_job_group") })
+	@Column(name = "id", nullable = false, unique = true)
+	private int id;
+	@Column(name = "app_name", length = 64, nullable = false)
+	@Comment("执行器AppName")
+	private String appname;
+	@Column(name = "title", length = 24, nullable = false)
+	@Comment("执行器名称")
+	private String title;
+	@Column(name = "address_type", nullable = false)
+	@ColumnDefault("0")
+	@Comment("执行器地址类型：0=自动注册、1=手动录入")
+	private int addressType; // 执行器地址类型：0=自动注册、1=手动录入
+	@Lob
+	@Column(name = "address_list", length = 16 * 1024)
+	@Comment("执行器地址列表，多地址逗号分隔")
+	private String addressList; // 执行器地址列表，多地址逗号分隔(手动录入)
+	@Temporal(TemporalType.TIMESTAMP)
+	@Column(name = "update_time")
+	private Date updateTime;
 
     // registry list
+    @Transient
     private List<String> registryList;  // 执行器地址列表(系统注册)
     public List<String> getRegistryList() {
         if (addressList!=null && addressList.trim().length()>0) {

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobInfo.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobInfo.java
@@ -2,44 +2,118 @@ package com.xxl.job.admin.core.model;
 
 import java.util.Date;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.Comment;
+import org.hibernate.annotations.GenericGenerator;
+
 /**
  * xxl-job info
  *
  * @author xuxueli  2016-1-12 18:25:49
  */
+@Entity
+@Table(name = "xxl_job_info")
 public class XxlJobInfo {
 	
+	@Id
+	@GeneratedValue(generator = "generator")
+	@GenericGenerator(name = "generator", strategy = "native", parameters = {
+			@org.hibernate.annotations.Parameter(name = "sequence_name", value = "s_xxl_job_info") })
+	@Column(name = "id", nullable = false, unique = true)
 	private int id;				// 主键ID
 	
+	@Column(name = "job_group", nullable = false)
+	@Comment("执行器主键ID")
 	private int jobGroup;		// 执行器主键ID
+	@Column(name = "job_desc", length = 255, nullable = false)
 	private String jobDesc;
 	
+	@Temporal(TemporalType.TIMESTAMP)
+	@Column(name = "add_time")
 	private Date addTime;
+	@Temporal(TemporalType.TIMESTAMP)
+	@Column(name = "update_time")
 	private Date updateTime;
 	
+	@Column(name = "author", length = 64)
+	@Comment("作者")
 	private String author;		// 负责人
+	@Column(name = "alarm_email", length = 255)
+	@Comment("报警邮件")
 	private String alarmEmail;	// 报警邮件
 
+	@Column(name = "schedule_type", length = 50, nullable = false)
+	@ColumnDefault("'NONE'")
+	@Comment("调度类型")
 	private String scheduleType;			// 调度类型
+	@Column(name = "schedule_conf", length = 128)
+	@Comment("调度配置，值含义取决于调度类型")
 	private String scheduleConf;			// 调度配置，值含义取决于调度类型
+	@Column(name = "misfire_strategy", length = 50, nullable = false)
+	@ColumnDefault("'DO_NOTHING'")
+	@Comment("调度过期策略")
 	private String misfireStrategy;			// 调度过期策略
 
+	@Column(name = "executor_route_strategy", length = 50)
+	@Comment("执行器路由策略")
 	private String executorRouteStrategy;	// 执行器路由策略
+	@Column(name = "executor_handler", length = 255)
+	@Comment("执行器任务handler")
 	private String executorHandler;		    // 执行器，任务Handler名称
+	@Column(name = "executor_param", length = 512)
+	@Comment("执行器任务参数")
 	private String executorParam;		    // 执行器，任务参数
+	@Column(name = "executor_block_strategy", length = 50)
+	@Comment("阻塞处理策略")
 	private String executorBlockStrategy;	// 阻塞处理策略
+	@Column(name = "executor_timeout", nullable = false)
+	@ColumnDefault("0")
+	@Comment("任务执行超时时间，单位秒")
 	private int executorTimeout;     		// 任务执行超时时间，单位秒
+	@Column(name = "executor_fail_retry_count", nullable = false)
+	@ColumnDefault("0")
+	@Comment("失败重试次数")
 	private int executorFailRetryCount;		// 失败重试次数
 	
+	@Column(name = "glue_type", length = 50, nullable = false)
+	@Comment("GLUE类型")
 	private String glueType;		// GLUE类型	#com.xxl.job.core.glue.GlueTypeEnum
+	@Lob
+	@Column(name = "glue_source", length = 16*1024*1024)
+	@Comment("GLUE源代码")
 	private String glueSource;		// GLUE源代码
+	@Column(name = "glue_remark", length = 128)
+	@Comment("GLUE备注")
 	private String glueRemark;		// GLUE备注
+	@Temporal(TemporalType.TIMESTAMP)
+	@Column(name="glue_updatetime")
+	@Comment("GLUE更新时间")
 	private Date glueUpdatetime;	// GLUE更新时间
 
+	@Column(name="child_jobid", length = 255)
+	@Comment("子任务ID，多个逗号分隔")
 	private String childJobId;		// 子任务ID，多个逗号分隔
 
+	@Column(name="trigger_status", nullable = false)
+	@ColumnDefault("0")
+	@Comment("调度状态：0-停止，1-运行")
 	private int triggerStatus;		// 调度状态：0-停止，1-运行
+	@Column(name="trigger_last_time", nullable = false)
+	@ColumnDefault("0")
+	@Comment("上次调度时间")
 	private long triggerLastTime;	// 上次调度时间
+	@Column(name="trigger_next_time", nullable = false)
+	@ColumnDefault("0")
+	@Comment("下次调度时间")
 	private long triggerNextTime;	// 下次调度时间
 
 

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobLock.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobLock.java
@@ -1,0 +1,31 @@
+package com.xxl.job.admin.core.model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.Comment;
+import org.hibernate.annotations.GenericGenerator;
+
+@Entity
+@Table(name = "xxl_job_lock")
+public class XxlJobLock {
+
+	@Id
+	@GeneratedValue(generator = "uuid")
+	@GenericGenerator(name = "uuid", strategy = "uuid")
+	@Column(name = "lock_name", length = 50, nullable = false, unique = true)
+	@Comment("锁名称")
+	private String lockName;
+
+	public String getLockName() {
+		return lockName;
+	}
+
+	public void setLockName(String lockName) {
+		this.lockName = lockName;
+	}
+
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobLog.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobLog.java
@@ -2,36 +2,92 @@ package com.xxl.job.admin.core.model;
 
 import java.util.Date;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.Lob;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.Comment;
+import org.hibernate.annotations.GenericGenerator;
+
 /**
  * xxl-job log, used to track trigger process
  * @author xuxueli  2015-12-19 23:19:09
  */
+@Entity
+@Table(name = "xxl_job_log", indexes = { @Index(name = "I_trigger_time", columnList = "trigger_time"),
+		@Index(name = "I_handle_code", columnList = "handle_code") })
 public class XxlJobLog {
 	
+	@Id
+	@GeneratedValue(generator = "generator")
+	@GenericGenerator(name = "generator", strategy = "native", parameters = {
+			@org.hibernate.annotations.Parameter(name = "sequence_name", value = "s_xxl_job_log") })
+	@Column(name = "id", nullable = false, unique = true)
 	private long id;
 	
 	// job info
+	@Column(name = "job_group", nullable = false)
+	@Comment("执行器主键ID")
 	private int jobGroup;
+	@Column(name = "job_id", nullable = false)
+	@Comment("任务，主键ID")
 	private int jobId;
 
 	// execute info
+	@Column(name = "executor_address", length = 255)
+	@Comment("执行器地址，本次执行的地址")
 	private String executorAddress;
+	@Column(name = "executor_handler", length = 255)
+	@Comment("执行器任务handler")
 	private String executorHandler;
+	@Column(name = "executor_param", length = 512)
+	@Comment("执行器任务参数")
 	private String executorParam;
+	@Column(name = "executor_sharding_param", length = 20)
+	@Comment("执行器任务分片参数，格式如 1/2")
 	private String executorShardingParam;
+	@Column(name = "executor_fail_retry_count", nullable = false)
+	@ColumnDefault("0")
+	@Comment("失败重试次数")
 	private int executorFailRetryCount;
 	
 	// trigger info
+	@Temporal(TemporalType.TIMESTAMP)
+	@Column(name = "trigger_time")
+	@Comment("调度-时间")
 	private Date triggerTime;
+	@Column(name = "trigger_code", nullable = false)
+	@Comment("调度-结果")
 	private int triggerCode;
+	@Lob
+	@Column(name = "trigger_msg", length = 16*1024)
+	@Comment("调度-日志")
 	private String triggerMsg;
 	
 	// handle info
+	@Temporal(TemporalType.TIMESTAMP)
+	@Column(name = "handle_time")
+	@Comment("执行-时间")
 	private Date handleTime;
+	@Column(name = "handle_code", nullable = false)
+	@Comment("执行-状态")
 	private int handleCode;
+	@Lob
+	@Column(name = "handle_msg", length = 16*1024)
+	@Comment("执行-日志")
 	private String handleMsg;
 
 	// alarm info
+	@Column(name = "alarm_status", nullable = false)
+	@ColumnDefault("0")
+	@Comment("告警状态：0-默认、1-无需告警、2-告警成功、3-告警失败")
 	private int alarmStatus;
 
 	public long getId() {

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobLogGlue.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobLogGlue.java
@@ -2,18 +2,50 @@ package com.xxl.job.admin.core.model;
 
 import java.util.Date;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+import org.hibernate.annotations.Comment;
+import org.hibernate.annotations.GenericGenerator;
+
 /**
  * xxl-job log for glue, used to track job code process
  * @author xuxueli 2016-5-19 17:57:46
  */
+@Entity
+@Table(name = "xxl_job_logglue")
 public class XxlJobLogGlue {
 	
+	@Id
+	@GeneratedValue(generator = "generator")
+	@GenericGenerator(name = "generator", strategy = "native", parameters = {
+			@org.hibernate.annotations.Parameter(name = "sequence_name", value = "s_xxl_job_logglue") })
+	@Column(name = "id", nullable = false, unique = true)
 	private int id;
+	@Column(name = "job_id", nullable = false)
+	@Comment("任务，主键ID")
 	private int jobId;				// 任务主键ID
+	@Column(name = "glue_type", length = 50)
+	@Comment("GLUE类型")
 	private String glueType;		// GLUE类型	#com.xxl.job.core.glue.GlueTypeEnum
+	@Lob
+	@Column(name = "glue_source", length = 16*1024*1024)
+	@Comment("GLUE源代码")
 	private String glueSource;
+	@Column(name = "glue_remark", length = 128, nullable = false)
+	@Comment("GLUE备注")
 	private String glueRemark;
+	@Temporal(TemporalType.TIMESTAMP)
+	@Column(name = "add_time")
 	private Date addTime;
+	@Temporal(TemporalType.TIMESTAMP)
+	@Column(name = "update_time")
 	private Date updateTime;
 
 	public int getId() {

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobLogReport.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobLogReport.java
@@ -2,14 +2,46 @@ package com.xxl.job.admin.core.model;
 
 import java.util.Date;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.Comment;
+import org.hibernate.annotations.GenericGenerator;
+
+@Entity
+@Table(name = "xxl_job_log_report", indexes = { @Index(name = "i_trigger_day", columnList = "trigger_day", unique = true) })
 public class XxlJobLogReport {
 
+	@Id
+	@GeneratedValue(generator = "generator")
+	@GenericGenerator(name = "generator", strategy = "native", parameters = {
+			@org.hibernate.annotations.Parameter(name = "sequence_name", value = "s_xxl_job_log_report") })
+	@Column(name = "id", nullable = false, unique = true)
     private int id;
 
+	@Temporal(TemporalType.TIMESTAMP)
+	@Column(name = "trigger_day")
+	@Comment("调度-时间")
     private Date triggerDay;
 
+	@Column(name = "running_count", nullable = false)
+	@ColumnDefault("0")
+	@Comment("运行中-日志数量")
     private int runningCount;
+	@Column(name = "suc_count", nullable = false)
+	@ColumnDefault("0")
+	@Comment("执行成功-日志数量")
     private int sucCount;
+	@Column(name = "fail_count", nullable = false)
+	@ColumnDefault("0")
+	@Comment("执行失败-日志数量")
     private int failCount;
 
     public int getId() {

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobRegistry.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobRegistry.java
@@ -2,15 +2,39 @@ package com.xxl.job.admin.core.model;
 
 import java.util.Date;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+import org.hibernate.annotations.GenericGenerator;
+
 /**
  * Created by xuxueli on 16/9/30.
  */
+@Entity
+@Table(name = "xxl_job_registry", indexes = {
+		@Index(name = "i_g_k_v", columnList = "registry_group,registry_key,registry_value") })
 public class XxlJobRegistry {
 
+	@Id
+	@GeneratedValue(generator = "generator")
+	@GenericGenerator(name = "generator", strategy = "native", parameters = {
+			@org.hibernate.annotations.Parameter(name = "sequence_name", value = "s_xxl_job_registry") })
+	@Column(name = "id", nullable = false, unique = true)
     private int id;
-    private String registryGroup;
+	@Column(name="registry_group", length = 50, nullable = false)
+	private String registryGroup;
+	 @Column(name="registry_key", length = 255, nullable = false)
     private String registryKey;
+	@Column(name="registry_value", length = 255, nullable = false)
     private String registryValue;
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="update_time")
     private Date updateTime;
 
     public int getId() {

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobUser.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobUser.java
@@ -1,16 +1,40 @@
 package com.xxl.job.admin.core.model;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.Comment;
+import org.hibernate.annotations.GenericGenerator;
 import org.springframework.util.StringUtils;
 
 /**
  * @author xuxueli 2019-05-04 16:43:12
  */
+@Entity
+@Table(name = "xxl_job_user", indexes = { @Index(name = "i_username", columnList = "username") })
 public class XxlJobUser {
 	
+	@Id
+	@GeneratedValue(generator = "generator")
+	@GenericGenerator(name = "generator", strategy = "native", parameters = {
+			@org.hibernate.annotations.Parameter(name = "sequence_name", value = "s_xxl_job_user") })
+	@Column(name = "id", nullable = false, unique = true)
 	private int id;
+	@Column(name="username", length = 50, nullable = false)
+	@Comment("账号")
 	private String username;		// 账号
+	@Column(name="password", length = 50, nullable = false)
+	@Comment("密码")
 	private String password;		// 密码
+	@Column(name="role", nullable = false)
+	@Comment("角色：0-普通用户、1-管理员")
 	private int role;				// 角色：0-普通用户、1-管理员
+	@Column(name="permission", length = 255)
+	@Comment("权限：执行器ID列表，多个逗号分割")
 	private String permission;	// 权限：执行器ID列表，多个逗号分割
 
 	public int getId() {

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/thread/JobScheduleHelper.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/thread/JobScheduleHelper.java
@@ -3,9 +3,12 @@ package com.xxl.job.admin.core.thread;
 import com.xxl.job.admin.core.conf.XxlJobAdminConfig;
 import com.xxl.job.admin.core.cron.CronExpression;
 import com.xxl.job.admin.core.model.XxlJobInfo;
+import com.xxl.job.admin.core.model.XxlJobLock;
 import com.xxl.job.admin.core.scheduler.MisfireStrategyEnum;
 import com.xxl.job.admin.core.scheduler.ScheduleTypeEnum;
 import com.xxl.job.admin.core.trigger.TriggerTypeEnum;
+import com.xxl.job.admin.core.util.EntityUtil;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,8 +72,8 @@ public class JobScheduleHelper {
                         conn = XxlJobAdminConfig.getAdminConfig().getDataSource().getConnection();
                         connAutoCommit = conn.getAutoCommit();
                         conn.setAutoCommit(false);
-
-                        preparedStatement = conn.prepareStatement(  "select * from xxl_job_lock where lock_name = 'schedule_lock' for update" );
+                        
+                        preparedStatement = conn.prepareStatement(  "select * from " + EntityUtil.getFullTablename(XxlJobLock.class) + " where lock_name = 'schedule_lock' for update" );
                         preparedStatement.execute();
 
                         // tx start

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/util/EntityUtil.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/util/EntityUtil.java
@@ -1,0 +1,33 @@
+package com.xxl.job.admin.core.util;
+
+import javax.persistence.Table;
+
+/**
+ * 
+ * @author spenggch 2022-09-30 15:57:02
+ *
+ */
+public class EntityUtil {
+
+	private static String XxlJobTablePrefix = null;
+
+	public static void setTablePrefix(String tablePrefix) {
+		XxlJobTablePrefix = tablePrefix;
+	}
+
+	public static String getFullTablename(Class<?> entityClass) {
+		String tableName = getTablename(entityClass);
+		if (tableName != null && XxlJobTablePrefix != null && XxlJobTablePrefix.length() > 1) {
+			tableName = XxlJobTablePrefix.trim() + tableName;
+		}
+		return tableName;
+	}
+
+	public static String getTablename(Class<?> entityClass) {
+		Table table = entityClass.getAnnotation(Table.class);
+		if (table != null) {
+			return table.name();
+		}
+		return null;
+	}
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/impl/XxlJobGroupDaoImpl.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/impl/XxlJobGroupDaoImpl.java
@@ -1,0 +1,100 @@
+package com.xxl.job.admin.dao.impl;
+
+import java.util.List;
+
+import javax.persistence.EntityManager;
+
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.xxl.job.admin.core.model.QXxlJobGroup;
+import com.xxl.job.admin.core.model.XxlJobGroup;
+import com.xxl.job.admin.dao.XxlJobGroupDao;
+
+@Component
+@Transactional
+public class XxlJobGroupDaoImpl implements XxlJobGroupDao {
+
+	@Autowired
+	EntityManager em;
+
+	@Override
+	public List<XxlJobGroup> findAll() {
+		return new JPAQueryFactory(em).select(QXxlJobGroup.xxlJobGroup).from(QXxlJobGroup.xxlJobGroup)
+				.orderBy(QXxlJobGroup.xxlJobGroup.appname.asc(), QXxlJobGroup.xxlJobGroup.title.asc(),
+						QXxlJobGroup.xxlJobGroup.id.asc())
+				.fetch();
+	}
+
+	@Override
+	public List<XxlJobGroup> findByAddressType(int addressType) {
+		return new JPAQueryFactory(em).select(QXxlJobGroup.xxlJobGroup).from(QXxlJobGroup.xxlJobGroup)
+				.where(QXxlJobGroup.xxlJobGroup.addressType.eq(addressType))
+				.orderBy(QXxlJobGroup.xxlJobGroup.appname.asc(), QXxlJobGroup.xxlJobGroup.title.asc(),
+						QXxlJobGroup.xxlJobGroup.id.asc())
+				.fetch();
+	}
+
+	@Override
+	public int save(XxlJobGroup xxlJobGroup) {
+		XxlJobGroup pi = em.merge(xxlJobGroup);
+		BeanUtils.copyProperties(pi, xxlJobGroup);
+		return 1;
+	}
+
+	@Override
+	public int update(XxlJobGroup xxlJobGroup) {
+		return (int) new JPAQueryFactory(em).update(QXxlJobGroup.xxlJobGroup)
+				.set(QXxlJobGroup.xxlJobGroup.appname, xxlJobGroup.getAppname())
+				.set(QXxlJobGroup.xxlJobGroup.title, xxlJobGroup.getTitle())
+				.set(QXxlJobGroup.xxlJobGroup.addressType, xxlJobGroup.getAddressType())
+				.set(QXxlJobGroup.xxlJobGroup.addressList, xxlJobGroup.getAddressList())
+				.set(QXxlJobGroup.xxlJobGroup.updateTime, xxlJobGroup.getUpdateTime())
+				.where(QXxlJobGroup.xxlJobGroup.id.eq(xxlJobGroup.getId())).execute();
+	}
+
+	@Override
+	public int remove(int id) {
+		return (int) new JPAQueryFactory(em).delete(QXxlJobGroup.xxlJobGroup).where(QXxlJobGroup.xxlJobGroup.id.eq(id))
+				.execute();
+	}
+
+	@Override
+	public XxlJobGroup load(int id) {
+		return em.find(XxlJobGroup.class, id);
+	}
+
+	@Override
+	public List<XxlJobGroup> pageList(int offset, int pagesize, String appname, String title) {
+		JPAQuery<XxlJobGroup> jpaQuery = new JPAQueryFactory(em).select(QXxlJobGroup.xxlJobGroup)
+				.from(QXxlJobGroup.xxlJobGroup);
+		if (appname != null && appname.length() > 0) {
+			jpaQuery.where(QXxlJobGroup.xxlJobGroup.appname.indexOf(appname).gt(-1));
+		}
+		if (title != null && title.length() > 0) {
+			jpaQuery.where(QXxlJobGroup.xxlJobGroup.title.indexOf(title).gt(-1));
+		}
+		jpaQuery.orderBy(QXxlJobGroup.xxlJobGroup.appname.asc(), QXxlJobGroup.xxlJobGroup.title.asc(),
+				QXxlJobGroup.xxlJobGroup.id.asc());
+		jpaQuery.offset(offset).limit(pagesize);
+		return jpaQuery.fetch();
+	}
+
+	@Override
+	public int pageListCount(int offset, int pagesize, String appname, String title) {
+		JPAQuery<Long> jpaQuery = new JPAQueryFactory(em).select(QXxlJobGroup.xxlJobGroup.count())
+				.from(QXxlJobGroup.xxlJobGroup);
+		if (appname != null && appname.length() > 0) {
+			jpaQuery.where(QXxlJobGroup.xxlJobGroup.appname.indexOf(appname).gt(-1));
+		}
+		if (title != null && title.length() > 0) {
+			jpaQuery.where(QXxlJobGroup.xxlJobGroup.title.indexOf(title).gt(-1));
+		}
+		return jpaQuery.fetchFirst().intValue();
+	}
+
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/impl/XxlJobInfoDaoImpl.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/impl/XxlJobInfoDaoImpl.java
@@ -1,0 +1,159 @@
+package com.xxl.job.admin.dao.impl;
+
+import java.util.List;
+
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import javax.persistence.EntityManager;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.xxl.job.admin.core.model.QXxlJobInfo;
+import com.xxl.job.admin.core.model.XxlJobInfo;
+import com.xxl.job.admin.dao.XxlJobInfoDao;
+
+@Component
+@Transactional
+public class XxlJobInfoDaoImpl implements XxlJobInfoDao {
+
+	@Autowired
+	EntityManager em;
+
+	@Override
+	public List<XxlJobInfo> pageList(int offset, int pagesize, int jobGroup, int triggerStatus, String jobDesc,
+			String executorHandler, String author) {
+		JPAQuery<XxlJobInfo> jpaQuery = new JPAQueryFactory(em).select(QXxlJobInfo.xxlJobInfo)
+				.from(QXxlJobInfo.xxlJobInfo);
+		if (jobGroup > 0) {
+			jpaQuery.where(QXxlJobInfo.xxlJobInfo.jobGroup.eq(jobGroup));
+		}
+		if (triggerStatus >= 0) {
+			jpaQuery.where(QXxlJobInfo.xxlJobInfo.triggerStatus.eq(triggerStatus));
+		}
+		if (jobDesc != null && jobDesc.length() > 0) {
+			jpaQuery.where(QXxlJobInfo.xxlJobInfo.jobDesc.indexOf(jobDesc).gt(-1));
+		}
+		if (executorHandler != null && executorHandler.length() > 0) {
+			jpaQuery.where(QXxlJobInfo.xxlJobInfo.executorHandler.indexOf(executorHandler).gt(-1));
+		}
+		if (author != null && author.length() > 0) {
+			jpaQuery.where(QXxlJobInfo.xxlJobInfo.author.indexOf(author).gt(-1));
+		}
+		jpaQuery.orderBy(QXxlJobInfo.xxlJobInfo.id.desc());
+		jpaQuery.offset(offset).limit(pagesize);
+		return jpaQuery.fetch();
+	}
+
+	@Override
+	public int pageListCount(int offset, int pagesize, int jobGroup, int triggerStatus, String jobDesc,
+			String executorHandler, String author) {
+		JPAQuery<Long> jpaQuery = new JPAQueryFactory(em).select(QXxlJobInfo.xxlJobInfo.count())
+				.from(QXxlJobInfo.xxlJobInfo);
+		if (jobGroup > 0) {
+			jpaQuery.where(QXxlJobInfo.xxlJobInfo.jobGroup.eq(jobGroup));
+		}
+		if (triggerStatus >= 0) {
+			jpaQuery.where(QXxlJobInfo.xxlJobInfo.triggerStatus.eq(triggerStatus));
+		}
+		if (jobDesc != null && jobDesc.length() > 0) {
+			jpaQuery.where(QXxlJobInfo.xxlJobInfo.jobDesc.indexOf(jobDesc).gt(-1));
+		}
+		if (executorHandler != null && executorHandler.length() > 0) {
+			jpaQuery.where(QXxlJobInfo.xxlJobInfo.executorHandler.indexOf(executorHandler).gt(-1));
+		}
+		if (author != null && author.length() > 0) {
+			jpaQuery.where(QXxlJobInfo.xxlJobInfo.author.indexOf(author).gt(-1));
+		}
+		return jpaQuery.fetchFirst().intValue();
+	}
+
+	@Override
+	public int save(XxlJobInfo info) {
+		if (info.getGlueSource() != null && info.getGlueSource().length() == 0) {
+			info.setGlueSource(null);
+		}
+		XxlJobInfo pi = em.merge(info);
+		BeanUtils.copyProperties(pi, info);
+		return 1;
+	}
+
+	@Override
+	public XxlJobInfo loadById(int id) {
+		return em.find(XxlJobInfo.class, id);
+	}
+
+	@Override
+	public int update(XxlJobInfo xxlJobInfo) {
+		if (xxlJobInfo.getGlueSource() != null && xxlJobInfo.getGlueSource().length() == 0) {
+			xxlJobInfo.setGlueSource(null);
+		}
+		return (int) new JPAQueryFactory(em).update(QXxlJobInfo.xxlJobInfo)
+				.set(QXxlJobInfo.xxlJobInfo.jobGroup, xxlJobInfo.getJobGroup())
+				.set(QXxlJobInfo.xxlJobInfo.jobDesc, xxlJobInfo.getJobDesc())
+				
+				.set(QXxlJobInfo.xxlJobInfo.updateTime, xxlJobInfo.getUpdateTime())
+				.set(QXxlJobInfo.xxlJobInfo.author, xxlJobInfo.getAuthor())
+				.set(QXxlJobInfo.xxlJobInfo.alarmEmail, xxlJobInfo.getAlarmEmail())
+				
+				.set(QXxlJobInfo.xxlJobInfo.scheduleType, xxlJobInfo.getScheduleType())
+				.set(QXxlJobInfo.xxlJobInfo.scheduleConf, xxlJobInfo.getScheduleConf())
+				.set(QXxlJobInfo.xxlJobInfo.misfireStrategy, xxlJobInfo.getMisfireStrategy())
+				
+				.set(QXxlJobInfo.xxlJobInfo.executorRouteStrategy, xxlJobInfo.getExecutorRouteStrategy())
+				.set(QXxlJobInfo.xxlJobInfo.executorHandler, xxlJobInfo.getExecutorHandler())
+				.set(QXxlJobInfo.xxlJobInfo.executorParam, xxlJobInfo.getExecutorParam())
+				.set(QXxlJobInfo.xxlJobInfo.executorBlockStrategy, xxlJobInfo.getExecutorBlockStrategy())
+				.set(QXxlJobInfo.xxlJobInfo.executorTimeout, xxlJobInfo.getExecutorTimeout())
+				.set(QXxlJobInfo.xxlJobInfo.executorFailRetryCount, xxlJobInfo.getExecutorFailRetryCount())
+				
+				.set(QXxlJobInfo.xxlJobInfo.glueType, xxlJobInfo.getGlueType())
+				.set(QXxlJobInfo.xxlJobInfo.glueSource, xxlJobInfo.getGlueSource())
+				.set(QXxlJobInfo.xxlJobInfo.glueRemark, xxlJobInfo.getGlueRemark())
+				.set(QXxlJobInfo.xxlJobInfo.glueUpdatetime, xxlJobInfo.getGlueUpdatetime())
+				
+				.set(QXxlJobInfo.xxlJobInfo.childJobId, xxlJobInfo.getChildJobId())
+				.set(QXxlJobInfo.xxlJobInfo.triggerStatus, xxlJobInfo.getTriggerStatus())
+				.set(QXxlJobInfo.xxlJobInfo.triggerLastTime, xxlJobInfo.getTriggerLastTime())
+				.set(QXxlJobInfo.xxlJobInfo.triggerNextTime, xxlJobInfo.getTriggerNextTime())
+				.where(QXxlJobInfo.xxlJobInfo.id.eq(xxlJobInfo.getId())).execute();
+	}
+
+	@Override
+	public int delete(long id) {
+		return (int) new JPAQueryFactory(em).delete(QXxlJobInfo.xxlJobInfo)
+				.where(QXxlJobInfo.xxlJobInfo.id.eq((int) id)).execute();
+	}
+
+	@Override
+	public List<XxlJobInfo> getJobsByGroup(int jobGroup) {
+		return new JPAQueryFactory(em).select(QXxlJobInfo.xxlJobInfo).from(QXxlJobInfo.xxlJobInfo)
+				.where(QXxlJobInfo.xxlJobInfo.jobGroup.eq(jobGroup)).fetch();
+	}
+
+	@Override
+	public int findAllCount() {
+		return new JPAQueryFactory(em).select(QXxlJobInfo.xxlJobInfo.count()).from(QXxlJobInfo.xxlJobInfo).fetchFirst()
+				.intValue();
+	}
+
+	@Override
+	public List<XxlJobInfo> scheduleJobQuery(long maxNextTime, int pagesize) {
+		return new JPAQueryFactory(em).select(QXxlJobInfo.xxlJobInfo).from(QXxlJobInfo.xxlJobInfo)
+				.where(QXxlJobInfo.xxlJobInfo.triggerStatus.eq(1),
+						QXxlJobInfo.xxlJobInfo.triggerNextTime.loe(maxNextTime))
+				.orderBy(QXxlJobInfo.xxlJobInfo.id.asc()).limit(pagesize).fetch();
+	}
+
+	@Override
+	public int scheduleUpdate(XxlJobInfo xxlJobInfo) {
+		return (int) new JPAQueryFactory(em).update(QXxlJobInfo.xxlJobInfo)
+				.set(QXxlJobInfo.xxlJobInfo.triggerLastTime, xxlJobInfo.getTriggerLastTime())
+				.set(QXxlJobInfo.xxlJobInfo.triggerNextTime, xxlJobInfo.getTriggerNextTime())
+				.set(QXxlJobInfo.xxlJobInfo.triggerStatus, xxlJobInfo.getTriggerStatus())
+				.where(QXxlJobInfo.xxlJobInfo.id.eq(xxlJobInfo.getId())).execute();
+	}
+
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/impl/XxlJobLogDaoImpl.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/impl/XxlJobLogDaoImpl.java
@@ -1,0 +1,212 @@
+package com.xxl.job.admin.dao.impl;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.persistence.EntityManager;
+
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.xxl.job.admin.core.model.QXxlJobLog;
+import com.xxl.job.admin.core.model.QXxlJobRegistry;
+import com.xxl.job.admin.core.model.XxlJobLog;
+import com.xxl.job.admin.dao.XxlJobLogDao;
+
+@Component
+@Transactional
+public class XxlJobLogDaoImpl implements XxlJobLogDao {
+
+	@Autowired
+	EntityManager em;
+
+	@Override
+	public List<XxlJobLog> pageList(int offset, int pagesize, int jobGroup, int jobId, Date triggerTimeStart,
+			Date triggerTimeEnd, int logStatus) {
+		JPAQuery<XxlJobLog> jpaQuery = new JPAQueryFactory(em).select(QXxlJobLog.xxlJobLog).from(QXxlJobLog.xxlJobLog);
+		if (jobId == 0 && jobGroup > 0) {
+			jpaQuery.where(QXxlJobLog.xxlJobLog.jobGroup.eq(jobGroup));
+		}
+		if (jobId > 0) {
+			jpaQuery.where(QXxlJobLog.xxlJobLog.jobId.eq(jobId));
+		}
+		if (triggerTimeStart != null) {
+			jpaQuery.where(QXxlJobLog.xxlJobLog.triggerTime.goe(triggerTimeStart));
+		}
+		if (triggerTimeEnd != null) {
+			jpaQuery.where(QXxlJobLog.xxlJobLog.triggerTime.loe(triggerTimeEnd));
+		}
+		if (logStatus == 1) {
+			jpaQuery.where(QXxlJobLog.xxlJobLog.handleCode.eq(200));
+		} else if (logStatus == 2) {
+			jpaQuery.where(
+					QXxlJobLog.xxlJobLog.triggerCode.notIn(0, 200).or(QXxlJobLog.xxlJobLog.handleCode.notIn(0, 200)));
+		} else if (logStatus == 3) {
+			jpaQuery.where(QXxlJobLog.xxlJobLog.triggerCode.eq(200));
+			jpaQuery.where(QXxlJobLog.xxlJobLog.handleCode.eq(0));
+		}
+		jpaQuery.orderBy(QXxlJobLog.xxlJobLog.triggerTime.desc());
+		jpaQuery.offset(offset).limit(pagesize);
+		return jpaQuery.fetch();
+	}
+
+	@Override
+	public int pageListCount(int offset, int pagesize, int jobGroup, int jobId, Date triggerTimeStart,
+			Date triggerTimeEnd, int logStatus) {
+		JPAQuery<Long> jpaQuery = new JPAQueryFactory(em).select(QXxlJobLog.xxlJobLog.count())
+				.from(QXxlJobLog.xxlJobLog);
+		if (jobId == 0 && jobGroup > 0) {
+			jpaQuery.where(QXxlJobLog.xxlJobLog.jobGroup.eq(jobGroup));
+		}
+		if (jobId > 0) {
+			jpaQuery.where(QXxlJobLog.xxlJobLog.jobId.eq(jobId));
+		}
+		if (triggerTimeStart != null) {
+			jpaQuery.where(QXxlJobLog.xxlJobLog.triggerTime.goe(triggerTimeStart));
+		}
+		if (triggerTimeEnd != null) {
+			jpaQuery.where(QXxlJobLog.xxlJobLog.triggerTime.loe(triggerTimeEnd));
+		}
+		if (logStatus == 1) {
+			jpaQuery.where(QXxlJobLog.xxlJobLog.handleCode.eq(200));
+		} else if (logStatus == 2) {
+			jpaQuery.where(
+					QXxlJobLog.xxlJobLog.triggerCode.notIn(0, 200).or(QXxlJobLog.xxlJobLog.handleCode.notIn(0, 200)));
+		} else if (logStatus == 3) {
+			jpaQuery.where(QXxlJobLog.xxlJobLog.triggerCode.eq(200));
+			jpaQuery.where(QXxlJobLog.xxlJobLog.handleCode.eq(0));
+		}
+		return jpaQuery.fetchFirst().intValue();
+	}
+
+	@Override
+	public XxlJobLog load(long id) {
+		return em.find(XxlJobLog.class, id);
+	}
+
+	@Override
+	public long save(XxlJobLog xxlJobLog) {
+		XxlJobLog pi = em.merge(xxlJobLog);
+		BeanUtils.copyProperties(pi, xxlJobLog);
+		return 1;
+	}
+
+	@Override
+	public int updateTriggerInfo(XxlJobLog xxlJobLog) {
+		return (int) new JPAQueryFactory(em).update(QXxlJobLog.xxlJobLog)
+				.set(QXxlJobLog.xxlJobLog.triggerTime, xxlJobLog.getTriggerTime())
+				.set(QXxlJobLog.xxlJobLog.triggerCode, xxlJobLog.getTriggerCode())
+				.set(QXxlJobLog.xxlJobLog.triggerMsg, xxlJobLog.getTriggerMsg())
+				.set(QXxlJobLog.xxlJobLog.executorAddress, xxlJobLog.getExecutorAddress())
+				.set(QXxlJobLog.xxlJobLog.executorHandler, xxlJobLog.getExecutorHandler())
+				.set(QXxlJobLog.xxlJobLog.executorParam, xxlJobLog.getExecutorParam())
+				.set(QXxlJobLog.xxlJobLog.executorShardingParam, xxlJobLog.getExecutorShardingParam())
+				.set(QXxlJobLog.xxlJobLog.executorFailRetryCount, xxlJobLog.getExecutorFailRetryCount())
+				.where(QXxlJobLog.xxlJobLog.id.eq(xxlJobLog.getId())).execute();
+	}
+
+	@Override
+	public int updateHandleInfo(XxlJobLog xxlJobLog) {
+		return (int) new JPAQueryFactory(em).update(QXxlJobLog.xxlJobLog)
+				.set(QXxlJobLog.xxlJobLog.handleTime, xxlJobLog.getHandleTime())
+				.set(QXxlJobLog.xxlJobLog.handleCode, xxlJobLog.getHandleCode())
+				.set(QXxlJobLog.xxlJobLog.handleMsg, xxlJobLog.getHandleMsg())
+				.where(QXxlJobLog.xxlJobLog.id.eq(xxlJobLog.getId())).execute();
+	}
+
+	@Override
+	public int delete(int jobId) {
+		return (int) new JPAQueryFactory(em).delete(QXxlJobLog.xxlJobLog).where(QXxlJobLog.xxlJobLog.jobId.eq(jobId))
+				.execute();
+	}
+
+	@Override
+	public Map<String, Object> findLogReport(Date from, Date to) {
+		Map<String, Object> map = new HashMap<String, Object>();
+
+		NumberExpression<Integer> triggerDayCountRunning = new CaseBuilder()
+				.when(QXxlJobLog.xxlJobLog.triggerCode.in(0, 200).and(QXxlJobLog.xxlJobLog.handleCode.eq(0))).then(1)
+				.otherwise(0);
+		Tuple tuple = new JPAQueryFactory(em)
+				.select(QXxlJobLog.xxlJobLog.handleCode.count(), triggerDayCountRunning.sum(),
+						QXxlJobLog.xxlJobLog.handleCode.when(200).then(1).otherwise(0).sum())
+				.from(QXxlJobLog.xxlJobLog).where(QXxlJobLog.xxlJobLog.triggerTime.between(from, to)).fetchFirst();
+		map.put("triggerDayCount", tuple.get(0, Integer.class));
+		map.put("triggerDayCountRunning", tuple.get(1, Integer.class) == null ? 0 : tuple.get(1, Integer.class));
+		map.put("triggerDayCountSuc", tuple.get(2, Integer.class) == null ? 0 : tuple.get(2, Integer.class));
+		return map;
+	}
+
+	@Override
+	public List<Long> findClearLogIds(int jobGroup, int jobId, Date clearBeforeTime, int clearBeforeNum, int pagesize) {
+		JPAQuery<Long> jpaQuery = new JPAQueryFactory(em).select(QXxlJobLog.xxlJobLog.id).from(QXxlJobLog.xxlJobLog);
+		if (jobGroup > 0) {
+			jpaQuery.where(QXxlJobLog.xxlJobLog.jobGroup.eq(jobGroup));
+		}
+		if (jobId > 0) {
+			jpaQuery.where(QXxlJobLog.xxlJobLog.jobId.eq(jobId));
+		}
+		if (clearBeforeTime != null) {
+			jpaQuery.where(QXxlJobLog.xxlJobLog.triggerTime.loe(clearBeforeTime));
+		}
+		if (clearBeforeNum > 0) {
+			JPAQuery<Long> sub = new JPAQuery<Long>().select(QXxlJobLog.xxlJobLog.id);
+			if (jobGroup > 0) {
+				sub.where(QXxlJobLog.xxlJobLog.jobGroup.eq(jobGroup));
+			}
+			if (jobId > 0) {
+				sub.where(QXxlJobLog.xxlJobLog.jobId.eq(jobId));
+			}
+			sub.orderBy(QXxlJobLog.xxlJobLog.triggerTime.desc());
+			sub.offset(0);
+			sub.limit(clearBeforeNum);
+			jpaQuery.where(QXxlJobLog.xxlJobLog.id.notIn(sub));
+		}
+		jpaQuery.orderBy(QXxlJobLog.xxlJobLog.id.asc());
+		jpaQuery.limit(pagesize);
+		return jpaQuery.fetch();
+	}
+
+	@Override
+	public int clearLog(List<Long> logIds) {
+		return (int) new JPAQueryFactory(em).delete(QXxlJobLog.xxlJobLog).where(QXxlJobLog.xxlJobLog.id.in(logIds))
+				.execute();
+	}
+
+	@Override
+	public List<Long> findFailJobLogIds(int pagesize) {
+		return new JPAQueryFactory(em).select(QXxlJobLog.xxlJobLog.id).from(QXxlJobLog.xxlJobLog)
+				.where(QXxlJobLog.xxlJobLog.alarmStatus.eq(0),
+						QXxlJobLog.xxlJobLog.triggerCode.in(0, 200).and(QXxlJobLog.xxlJobLog.handleCode.eq(0))
+								.or(QXxlJobLog.xxlJobLog.handleCode.eq(200)).not())
+				.orderBy(QXxlJobLog.xxlJobLog.id.asc()).fetch();
+	}
+
+	@Override
+	public int updateAlarmStatus(long logId, int oldAlarmStatus, int newAlarmStatus) {
+		return (int) new JPAQueryFactory(em).update(QXxlJobLog.xxlJobLog)
+				.set(QXxlJobLog.xxlJobLog.alarmStatus, newAlarmStatus)
+				.where(QXxlJobLog.xxlJobLog.id.eq(logId), QXxlJobLog.xxlJobLog.alarmStatus.eq(oldAlarmStatus))
+				.execute();
+	}
+
+	@Override
+	public List<Long> findLostJobIds(Date losedTime) {
+		return new JPAQueryFactory(em).select(QXxlJobLog.xxlJobLog.id).from(QXxlJobLog.xxlJobLog)
+				.leftJoin(QXxlJobRegistry.xxlJobRegistry)
+				.on(QXxlJobLog.xxlJobLog.executorAddress.eq(QXxlJobRegistry.xxlJobRegistry.registryValue))
+				.where(QXxlJobLog.xxlJobLog.triggerCode.eq(200), QXxlJobLog.xxlJobLog.handleCode.eq(0),
+						QXxlJobLog.xxlJobLog.triggerTime.loe(losedTime), QXxlJobRegistry.xxlJobRegistry.id.isNull())
+				.fetch();
+	}
+
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/impl/XxlJobLogGlueDaoImpl.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/impl/XxlJobLogGlueDaoImpl.java
@@ -1,0 +1,55 @@
+package com.xxl.job.admin.dao.impl;
+
+import java.util.List;
+
+import javax.persistence.EntityManager;
+
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.xxl.job.admin.core.model.QXxlJobLogGlue;
+import com.xxl.job.admin.core.model.XxlJobLogGlue;
+import com.xxl.job.admin.dao.XxlJobLogGlueDao;
+
+@Component
+@Transactional
+public class XxlJobLogGlueDaoImpl implements XxlJobLogGlueDao {
+
+	@Autowired
+	EntityManager em;
+
+	@Override
+	public int save(XxlJobLogGlue xxlJobLogGlue) {
+		XxlJobLogGlue pi = em.merge(xxlJobLogGlue);
+		BeanUtils.copyProperties(pi, xxlJobLogGlue);
+		return 1;
+	}
+
+	@Override
+	public List<XxlJobLogGlue> findByJobId(int jobId) {
+		return new JPAQueryFactory(em).select(QXxlJobLogGlue.xxlJobLogGlue).from(QXxlJobLogGlue.xxlJobLogGlue)
+				.where(QXxlJobLogGlue.xxlJobLogGlue.jobId.eq(jobId)).orderBy(QXxlJobLogGlue.xxlJobLogGlue.id.desc())
+				.fetch();
+	}
+
+	@Override
+	public int removeOld(int jobId, int limit) {
+		JPAQuery<Integer> sub = new JPAQuery<Long>().select(QXxlJobLogGlue.xxlJobLogGlue.id)
+				.from(QXxlJobLogGlue.xxlJobLogGlue).where(QXxlJobLogGlue.xxlJobLogGlue.jobId.eq(jobId))
+				.orderBy(QXxlJobLogGlue.xxlJobLogGlue.updateTime.desc()).offset(limit);
+		return (int) new JPAQueryFactory(em).delete(QXxlJobLogGlue.xxlJobLogGlue)
+				.where(QXxlJobLogGlue.xxlJobLogGlue.jobId.eq(jobId), QXxlJobLogGlue.xxlJobLogGlue.id.notIn(sub))
+				.execute();
+	}
+
+	@Override
+	public int deleteByJobId(int jobId) {
+		return (int) new JPAQueryFactory(em).delete(QXxlJobLogGlue.xxlJobLogGlue)
+				.where(QXxlJobLogGlue.xxlJobLogGlue.jobId.eq(jobId)).execute();
+	}
+
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/impl/XxlJobLogReportDaoImpl.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/impl/XxlJobLogReportDaoImpl.java
@@ -1,0 +1,72 @@
+package com.xxl.job.admin.dao.impl;
+
+import java.util.Date;
+import java.util.List;
+
+import javax.persistence.EntityManager;
+
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.xxl.job.admin.core.model.QXxlJobLogReport;
+import com.xxl.job.admin.core.model.XxlJobLogReport;
+import com.xxl.job.admin.dao.XxlJobLogReportDao;
+
+@Component
+@Transactional
+public class XxlJobLogReportDaoImpl implements XxlJobLogReportDao {
+
+	@Autowired
+	EntityManager em;
+
+	@Override
+	public int save(XxlJobLogReport xxlJobLogReport) {
+		XxlJobLogReport pi = em.merge(xxlJobLogReport);
+		BeanUtils.copyProperties(pi, xxlJobLogReport);
+		return 1;
+	}
+
+	@Override
+	public int update(XxlJobLogReport xxlJobLogReport) {
+		return (int) new JPAQueryFactory(em).update(QXxlJobLogReport.xxlJobLogReport)
+				.set(QXxlJobLogReport.xxlJobLogReport.runningCount, xxlJobLogReport.getRunningCount())
+				.set(QXxlJobLogReport.xxlJobLogReport.sucCount, xxlJobLogReport.getSucCount())
+				.set(QXxlJobLogReport.xxlJobLogReport.failCount, xxlJobLogReport.getFailCount())
+				.where(QXxlJobLogReport.xxlJobLogReport.triggerDay.eq(xxlJobLogReport.getTriggerDay())).execute();
+	}
+
+	@Override
+	public List<XxlJobLogReport> queryLogReport(Date triggerDayFrom, Date triggerDayTo) {
+		return new JPAQueryFactory(em).select(QXxlJobLogReport.xxlJobLogReport).from(QXxlJobLogReport.xxlJobLogReport)
+				.where(QXxlJobLogReport.xxlJobLogReport.triggerDay.between(triggerDayFrom, triggerDayTo))
+				.orderBy(QXxlJobLogReport.xxlJobLogReport.triggerDay.asc()).fetch();
+	}
+
+	@Override
+	public XxlJobLogReport queryLogReportTotal() {
+
+		Tuple tuple = new JPAQueryFactory(em).select(QXxlJobLogReport.xxlJobLogReport.runningCount.sum(),
+				QXxlJobLogReport.xxlJobLogReport.sucCount.sum(), QXxlJobLogReport.xxlJobLogReport.failCount.sum())
+				.from(QXxlJobLogReport.xxlJobLogReport).fetchFirst();
+		XxlJobLogReport report = null;
+		if (tuple != null) {
+			report = new XxlJobLogReport();
+			Object[] arr = tuple.toArray();
+			if (arr[0] != null) {
+				report.setRunningCount(Integer.parseInt(arr[0].toString()));
+			}
+			if (arr[1] != null) {
+				report.setSucCount(Integer.parseInt(arr[1].toString()));
+			}
+			if (arr[2] != null) {
+				report.setFailCount(Integer.parseInt(arr[2].toString()));
+			}
+		}
+		return report;
+	}
+
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/impl/XxlJobRegistryDaoImpl.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/impl/XxlJobRegistryDaoImpl.java
@@ -1,0 +1,84 @@
+package com.xxl.job.admin.dao.impl;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+
+import javax.persistence.EntityManager;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.xxl.job.admin.core.model.QXxlJobRegistry;
+import com.xxl.job.admin.core.model.XxlJobRegistry;
+import com.xxl.job.admin.dao.XxlJobRegistryDao;
+
+@Component
+@Transactional
+public class XxlJobRegistryDaoImpl implements XxlJobRegistryDao {
+
+	@Autowired
+	EntityManager em;
+
+	@Override
+	public List<Integer> findDead(int timeout, Date nowTime) {
+		Calendar calendar = Calendar.getInstance();
+		calendar.setTime(nowTime);
+		calendar.add(Calendar.SECOND, 0 - timeout);
+		Date limitTime = calendar.getTime();
+		return new JPAQueryFactory(em).select(QXxlJobRegistry.xxlJobRegistry.id).from(QXxlJobRegistry.xxlJobRegistry)
+				.where(QXxlJobRegistry.xxlJobRegistry.updateTime.lt(limitTime)).fetch();
+	}
+
+	@Override
+	public int removeDead(List<Integer> ids) {
+		if (ids != null && ids.size() > 0) {
+			return (int) new JPAQueryFactory(em).delete(QXxlJobRegistry.xxlJobRegistry)
+					.where(QXxlJobRegistry.xxlJobRegistry.id.in(ids)).execute();
+		}
+		return 1;
+	}
+
+	@Override
+	public List<XxlJobRegistry> findAll(int timeout, Date nowTime) {
+		Calendar calendar = Calendar.getInstance();
+		calendar.setTime(nowTime);
+		calendar.add(Calendar.SECOND, 0 - timeout);
+		Date limitTime = calendar.getTime();
+		return new JPAQueryFactory(em).select(QXxlJobRegistry.xxlJobRegistry).from(QXxlJobRegistry.xxlJobRegistry)
+				.where(QXxlJobRegistry.xxlJobRegistry.updateTime.gt(limitTime)).fetch();
+	}
+
+	@Override
+	public int registryUpdate(String registryGroup, String registryKey, String registryValue, Date updateTime) {
+		return (int) new JPAQueryFactory(em).update(QXxlJobRegistry.xxlJobRegistry)
+				.set(QXxlJobRegistry.xxlJobRegistry.updateTime, updateTime)
+				.where(QXxlJobRegistry.xxlJobRegistry.registryGroup.eq(registryGroup),
+						QXxlJobRegistry.xxlJobRegistry.registryKey.eq(registryKey),
+						QXxlJobRegistry.xxlJobRegistry.registryValue.eq(registryValue))
+				.execute();
+	}
+
+	@Override
+	public int registrySave(String registryGroup, String registryKey, String registryValue, Date updateTime) {
+		XxlJobRegistry registry = new XxlJobRegistry();
+		registry.setRegistryGroup(registryGroup);
+		registry.setRegistryKey(registryKey);
+		registry.setRegistryValue(registryValue);
+		registry.setUpdateTime(updateTime);
+		registry = em.merge(registry);
+		return 1;
+	}
+
+	@Override
+	public int registryDelete(String registryGroup, String registryKey, String registryValue) {
+		return (int) new JPAQueryFactory(em).delete(QXxlJobRegistry.xxlJobRegistry)
+				.where(QXxlJobRegistry.xxlJobRegistry.registryGroup.eq(registryGroup),
+						QXxlJobRegistry.xxlJobRegistry.registryKey.eq(registryKey),
+						QXxlJobRegistry.xxlJobRegistry.registryValue.eq(registryValue))
+				.execute();
+	}
+
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/impl/XxlJobUserDaoImpl.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/dao/impl/XxlJobUserDaoImpl.java
@@ -1,0 +1,85 @@
+package com.xxl.job.admin.dao.impl;
+
+import java.util.List;
+
+import javax.persistence.EntityManager;
+
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.querydsl.jpa.impl.JPAUpdateClause;
+import com.xxl.job.admin.core.model.QXxlJobUser;
+import com.xxl.job.admin.core.model.XxlJobUser;
+import com.xxl.job.admin.dao.XxlJobUserDao;
+
+@Component
+@Transactional
+public class XxlJobUserDaoImpl implements XxlJobUserDao {
+
+	@Autowired
+	EntityManager em;
+
+	@Override
+	public List<XxlJobUser> pageList(int offset, int pagesize, String username, int role) {
+		JPAQuery<XxlJobUser> jpaQuery = new JPAQueryFactory(em).select(QXxlJobUser.xxlJobUser)
+				.from(QXxlJobUser.xxlJobUser);
+		if (username != null && username.length() > 0) {
+			jpaQuery.where(QXxlJobUser.xxlJobUser.username.indexOf(username).gt(-1));
+		}
+		if (role > -1) {
+			jpaQuery.where(QXxlJobUser.xxlJobUser.role.eq(role));
+		}
+		jpaQuery.orderBy(QXxlJobUser.xxlJobUser.username.asc());
+		jpaQuery.offset(offset).limit(pagesize);
+		return jpaQuery.fetch();
+	}
+
+	@Override
+	public int pageListCount(int offset, int pagesize, String username, int role) {
+		JPAQuery<Long> jpaQuery = new JPAQueryFactory(em).select(QXxlJobUser.xxlJobUser.count())
+				.from(QXxlJobUser.xxlJobUser);
+		if (username != null && username.length() > 0) {
+			jpaQuery.where(QXxlJobUser.xxlJobUser.username.indexOf(username).gt(-1));
+		}
+		if (role > -1) {
+			jpaQuery.where(QXxlJobUser.xxlJobUser.role.eq(role));
+		}
+		return jpaQuery.fetchFirst().intValue();
+	}
+
+	@Override
+	public XxlJobUser loadByUserName(String username) {
+		return new JPAQueryFactory(em).select(QXxlJobUser.xxlJobUser).from(QXxlJobUser.xxlJobUser)
+				.where(QXxlJobUser.xxlJobUser.username.eq(username)).fetchFirst();
+	}
+
+	@Override
+	public int save(XxlJobUser xxlJobUser) {
+		XxlJobUser pi = em.merge(xxlJobUser);
+		BeanUtils.copyProperties(pi, xxlJobUser);
+		return xxlJobUser.getId();
+	}
+
+	@Override
+	public int update(XxlJobUser xxlJobUser) {
+		JPAUpdateClause update = new JPAQueryFactory(em).update(QXxlJobUser.xxlJobUser);
+		if (xxlJobUser.getPassword() != null && xxlJobUser.getPassword().length() > 0) {
+			update.set(QXxlJobUser.xxlJobUser.password, xxlJobUser.getPassword());
+		}
+		update.set(QXxlJobUser.xxlJobUser.role, xxlJobUser.getRole());
+		update.set(QXxlJobUser.xxlJobUser.permission, xxlJobUser.getPermission());
+		update.where(QXxlJobUser.xxlJobUser.id.eq(xxlJobUser.getId()));
+		return (int) update.execute();
+	}
+
+	@Override
+	public int delete(int id) {
+		return (int) new JPAQueryFactory(em).delete(QXxlJobUser.xxlJobUser).where(QXxlJobUser.xxlJobUser.id.eq(id))
+				.execute();
+	}
+
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/service/SystemService.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/service/SystemService.java
@@ -1,0 +1,12 @@
+package com.xxl.job.admin.service;
+
+/**
+ * System Loading Service
+ *
+ * @author spenggch 2022-09-30 14:42:00
+ */
+public interface SystemService {
+
+	void initializeData();
+
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/service/impl/SystemServiceImpl.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/service/impl/SystemServiceImpl.java
@@ -1,0 +1,82 @@
+package com.xxl.job.admin.service.impl;
+
+import javax.persistence.EntityManager;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.xxl.job.admin.core.model.XxlJobGroup;
+import com.xxl.job.admin.core.model.XxlJobInfo;
+import com.xxl.job.admin.core.model.XxlJobLock;
+import com.xxl.job.admin.core.model.XxlJobUser;
+import com.xxl.job.admin.core.util.EntityUtil;
+import com.xxl.job.admin.service.SystemService;
+import com.xxl.job.core.util.DateUtil;
+
+/**
+ * 
+ * @author spenggch 2022-09-30 14:46:28
+ *
+ */
+@Component
+public class SystemServiceImpl implements SystemService {
+
+	@Autowired(required = false)
+	EntityManager em;
+
+	@Override
+	@Transactional
+	public void initializeData() {
+		if (em == null) {
+			return;
+		}
+		Object cn = em.createQuery("select count(*) from " + XxlJobUser.class.getSimpleName()).getSingleResult();
+		if (Integer.parseInt(cn.toString()) > 0) {
+			return;
+		}
+		XxlJobGroup xxlJobGroup = new XxlJobGroup();
+		xxlJobGroup.setAppname("xxl-job-executor-sample");
+		xxlJobGroup.setTitle("示例执行器");
+		xxlJobGroup.setAddressType(0);
+		xxlJobGroup.setAddressList(null);
+		xxlJobGroup.setUpdateTime(DateUtil.parse("2018-11-03 22:21:31", "yyyy-MM-dd HH:mm:ss"));
+		em.persist(xxlJobGroup);
+
+		XxlJobInfo xxlJobInfo = new XxlJobInfo();
+		xxlJobInfo.setJobGroup(xxlJobGroup.getId());
+		xxlJobInfo.setJobDesc("测试任务1");
+		xxlJobInfo.setAddTime(DateUtil.parse("2018-11-03 22:21:31", "yyyy-MM-dd HH:mm:ss"));
+		xxlJobInfo.setUpdateTime(DateUtil.parse("2018-11-03 22:21:31", "yyyy-MM-dd HH:mm:ss"));
+		xxlJobInfo.setAuthor("XXL");
+		xxlJobInfo.setAlarmEmail(null);
+		xxlJobInfo.setScheduleType("CRON");
+		xxlJobInfo.setScheduleConf("0 0 0 * * ? *");
+		xxlJobInfo.setMisfireStrategy("DO_NOTHING");
+		xxlJobInfo.setExecutorRouteStrategy("FIRST");
+		xxlJobInfo.setExecutorHandler("demoJobHandler");
+		xxlJobInfo.setExecutorParam(null);
+		xxlJobInfo.setExecutorBlockStrategy("SERIAL_EXECUTION");
+		xxlJobInfo.setExecutorTimeout(0);
+		xxlJobInfo.setExecutorFailRetryCount(0);
+		xxlJobInfo.setGlueType("BEAN");
+		xxlJobInfo.setGlueSource(null);
+		xxlJobInfo.setGlueRemark("GLUE代码初始化");
+		xxlJobInfo.setGlueUpdatetime(DateUtil.parse("2018-11-03 22:21:31", "yyyy-MM-dd HH:mm:ss"));
+		xxlJobInfo.setChildJobId(null);
+		em.persist(xxlJobInfo);
+
+		XxlJobUser xxlJobUser = new XxlJobUser();
+		xxlJobUser.setUsername("admin");
+		xxlJobUser.setPassword("e10adc3949ba59abbe56e057f20f883e");
+		xxlJobUser.setRole(1);
+		xxlJobUser.setPermission(null);
+		em.persist(xxlJobUser);
+
+		em.createNativeQuery(
+				"insert into " + EntityUtil.getFullTablename(XxlJobLock.class) + " values ('schedule_lock') ")
+				.executeUpdate();
+
+	}
+
+}

--- a/xxl-job-admin/src/main/resources/application.properties
+++ b/xxl-job-admin/src/main/resources/application.properties
@@ -28,6 +28,11 @@ spring.datasource.username=root
 spring.datasource.password=root_pwd
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
+#spring.jpa.properties.hibernate.default_schema=xxl_job
+spring.jpa.show-sql=true
+spring.jpa.generate-ddl=true
+
 ### datasource-pool
 spring.datasource.type=com.zaxxer.hikari.HikariDataSource
 spring.datasource.hikari.minimum-idle=10
@@ -37,7 +42,7 @@ spring.datasource.hikari.idle-timeout=30000
 spring.datasource.hikari.pool-name=HikariCP
 spring.datasource.hikari.max-lifetime=900000
 spring.datasource.hikari.connection-timeout=10000
-spring.datasource.hikari.connection-test-query=SELECT 1
+#spring.datasource.hikari.connection-test-query=SELECT 1
 spring.datasource.hikari.validation-timeout=1000
 
 ### xxl-job, email
@@ -50,6 +55,8 @@ spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 spring.mail.properties.mail.smtp.starttls.required=true
 spring.mail.properties.mail.smtp.socketFactory.class=javax.net.ssl.SSLSocketFactory
+
+xxl.job.table.prefix=${spring.jpa.properties.hibernate.default_schema:}.
 
 ### xxl-job, access token
 xxl.job.accessToken=default_token


### PR DESCRIPTION
1、将mybatis更换为jpa，实现全数据库支持
2、sql查询使用querydsl取代
3、取消spring.datasource.hikari.connection-test-query的配置，hikaricp使用了更高级的检测方式，主流数据库版本都支持，对于较早的数据库，可以根据需要开启 
4、mybatis的注解依赖和mapper配置文件未删除，但是已经无效了

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**


**Other information:**