### PR TITLE
Netty 依赖相关 微调

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.test.skip>true</maven.test.skip>
 
-		<netty-all.version>4.1.63.Final</netty-all.version>
+		<netty.version>4.1.63.Final</netty.version>
 		<gson.version>2.9.0</gson.version>
 
 		<spring.version>5.3.20</spring.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.test.skip>true</maven.test.skip>
 
-		<netty.version>4.1.63.Final</netty.version>
+		<netty.version>4.1.82.Final</netty.version>
 		<gson.version>2.9.0</gson.version>
 
 		<spring.version>5.3.20</spring.version>

--- a/xxl-job-core/pom.xml
+++ b/xxl-job-core/pom.xml
@@ -13,13 +13,24 @@
 	<description>A distributed task scheduling framework.</description>
 	<url>https://www.xuxueli.com/</url>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-bom</artifactId>
+				<version>${netty.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 
 		<!-- ********************** embed server: netty + gson ********************** -->
 		<dependency>
 			<groupId>io.netty</groupId>
-			<artifactId>netty-all</artifactId>
-			<version>${netty-all.version}</version>
+			<artifactId>netty-codec-http</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
- [√ ] Build-related changes


**The description of the PR:**
1. 使用 netty-bom 统一管理 netty 依赖，后续各个工程 module 引入 netty 具体模块时无需关心版本号
2. 减少执行器的传递依赖：引入 xxl-job-core 的 Java 工程只会传递使用到的数个 netty 依赖
3. 升级 netty 至最新版