### PR TITLE
添加mysql配置环境变量，用于mysql密码存在特殊字符无法正确解析

### DIFF
--- a/xxl-job-admin/src/main/resources/application.properties
+++ b/xxl-job-admin/src/main/resources/application.properties
@@ -23,9 +23,9 @@ mybatis.mapper-locations=classpath:/mybatis-mapper/*Mapper.xml
 #mybatis.type-aliases-package=com.xxl.job.admin.core.model
 
 ### xxl-job, datasource
-spring.datasource.url=jdbc:mysql://127.0.0.1:3306/xxl_job?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&serverTimezone=Asia/Shanghai
-spring.datasource.username=root
-spring.datasource.password=root_pwd
+spring.datasource.url=${MYSQL_URL:jdbc:mysql://127.0.0.1:3306/xxl_job?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&serverTimezone=Asia/Shanghai}
+spring.datasource.username=${MYSQL_USERNAME:root}
+spring.datasource.password=${MYSQL_PASSWORD:root_pwd}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 ### datasource-pool


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**
今天测试了下docker方式运行xxl-job-admin，发现在PARAMS参数中无法解析特殊字符，无论是单引号还是反斜杠都会导致密码无法正确输入！

单引号会提示
```
-bash: !9: event not found
```
![输入图片说明](https://foruda.gitee.com/images/1681971309625358906/76f58063_1543990.png "屏幕截图")

而在感叹号前加反斜杠会被识别成双斜杠

![输入图片说明](https://foruda.gitee.com/images/1681971471907026818/033a0940_1543990.png "屏幕截图")


此处主要是添加环境变量参数，这样可以不通过PARAMS参数来传递mysql配置信息，解决特殊字符在PARAMS中无法正确转义的问题