### PR TITLE
添加索引，提高删除任务的速度

### DIFF
--- a/doc/db/tables_xxl_job.sql
+++ b/doc/db/tables_xxl_job.sql
@@ -53,7 +53,8 @@ CREATE TABLE `xxl_job_log` (
   `alarm_status` tinyint(4) NOT NULL DEFAULT '0' COMMENT '告警状态：0-默认、1-无需告警、2-告警成功、3-告警失败',
   PRIMARY KEY (`id`),
   KEY `I_trigger_time` (`trigger_time`),
-  KEY `I_handle_code` (`handle_code`)
+  KEY `I_handle_code` (`handle_code`),
+  KEY `I_job_id` (`job_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `xxl_job_log_report` (


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Feature

**The description of the PR:**

当前删除任务时，也会同时删除任务所有的执行日志，[代码](https://github.com/xuxueli/xxl-job/blob/6effc8b98f0fd5b5af3a7b6a8995bdcf30de69fc/xxl-job-admin/src/main/java/com/xxl/job/admin/service/impl/XxlJobServiceImpl.java#LL298C3-L298C27)在这里。

如果log表数据量非常大的时候，根据`job_id`删除日志的执行时间会非常大，导致删除任务的时间也很长。

因此解决方案是在创建`xxl_job_log`表时，给`job_id`字段加上索引