### PR TITLE
fix(sec): upgrade com.mysql:mysql-connector-j to 8.0.33

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 		<spring-boot.version>2.7.9</spring-boot.version>
 
 		<mybatis-spring-boot-starter.version>2.3.0</mybatis-spring-boot-starter.version>
-		<mysql-connector-j.version>8.0.32</mysql-connector-j.version>
+		<mysql-connector-j.version>8.0.33</mysql-connector-j.version>
 
 		<slf4j-api.version>1.7.36</slf4j-api.version>
 		<junit-jupiter.version>5.9.2</junit-jupiter.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.mysql:mysql-connector-j 8.0.32
- [CVE-2023-21971](https://www.oscs1024.com/hd/CVE-2023-21971)


### What did I do？
Upgrade com.mysql:mysql-connector-j from 8.0.32 to 8.0.33 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS