### PR TITLE
fix：修复刷新最近3天内报表数据时，未更新update_time字段

### DIFF
--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobLogReport.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/model/XxlJobLogReport.java
@@ -12,6 +12,8 @@ public class XxlJobLogReport {
     private int sucCount;
     private int failCount;
 
+    private Date updateTime;
+
     public int getId() {
         return id;
     }
@@ -50,5 +52,13 @@ public class XxlJobLogReport {
 
     public void setFailCount(int failCount) {
         this.failCount = failCount;
+    }
+
+    public Date getUpdateTime() {
+        return updateTime;
+    }
+
+    public void setUpdateTime(Date updateTime) {
+        this.updateTime = updateTime;
     }
 }

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/thread/JobLogReportHelper.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/thread/JobLogReportHelper.java
@@ -79,6 +79,7 @@ public class JobLogReportHelper {
                                 xxlJobLogReport.setSucCount(triggerDayCountSuc);
                                 xxlJobLogReport.setFailCount(triggerDayCountFail);
                             }
+                            xxlJobLogReport.setUpdateTime(new Date());
 
                             // do refresh
                             int ret = XxlJobAdminConfig.getAdminConfig().getXxlJobLogReportDao().update(xxlJobLogReport);

--- a/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobLogReportMapper.xml
+++ b/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobLogReportMapper.xml
@@ -40,7 +40,8 @@
         UPDATE xxl_job_log_report
         SET `running_count` = #{runningCount},
         	`suc_count` = #{sucCount},
-        	`fail_count` = #{failCount}
+        	`fail_count` = #{failCount},
+		    `update_time` = #{updateTime}
         WHERE `trigger_day` = #{triggerDay}
     </update>
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**The description of the PR:**

XxlJobLogReport实体类没有updateTime字段，定时任务在刷新3天内报表数据时，未更新报表的update_time字段

![before](https://github.com/xuxueli/xxl-job/assets/114419098/47d68b50-f988-4c0a-8e6b-1590b4bd62cb)

修复后已自测

![after](https://github.com/xuxueli/xxl-job/assets/114419098/a8a3266f-5bcb-425e-994a-3165ac3337e0)

**Other information:**
