### PR TITLE
任务配置 JobHandler 属性取值描述错误

### DIFF
--- a/doc/XXL-JOB官方文档.md
+++ b/doc/XXL-JOB官方文档.md
@@ -1037,7 +1037,7 @@ public XxlJobSpringExecutor xxlJobExecutor() {
             GLUE模式(PHP)：任务以源码方式维护在调度中心；该模式的任务实际上是一段 "php" 脚本；
             GLUE模式(NodeJS)：任务以源码方式维护在调度中心；该模式的任务实际上是一段 "nodejs" 脚本；
             GLUE模式(PowerShell)：任务以源码方式维护在调度中心；该模式的任务实际上是一段 "PowerShell" 脚本；
-        - JobHandler：运行模式为 "BEAN模式" 时生效，对应执行器中新开发的JobHandler类“@JobHandler”注解自定义的value值；
+        - JobHandler：运行模式为 "BEAN模式" 时生效，对应执行器中新开发的JobHandler类“@XxlJob”注解自定义的value值；
         - 执行参数：任务执行所需的参数；     
         
     高级配置：


### PR DESCRIPTION
任务配置JobHandler 取自注解@XxlJob的value值，而文档描述取自@JobHandler注解的value值

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**
任务配置JobHandler 取自注解@XxlJob的value值，而文档描述取自@JobHandler注解的value值

**Other information:**