### PR TITLE
XxlJobSpringExecutor 提供是否立即start选项供用户使用，在某些客户端有自己的初始化逻辑的时候，用户可自己控制未完成…

### DIFF
--- a/xxl-job-core/src/main/java/com/xxl/job/core/executor/impl/XxlJobSpringExecutor.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/executor/impl/XxlJobSpringExecutor.java
@@ -26,6 +26,15 @@ import java.util.Map;
 public class XxlJobSpringExecutor extends XxlJobExecutor implements ApplicationContextAware, SmartInitializingSingleton, DisposableBean {
     private static final Logger logger = LoggerFactory.getLogger(XxlJobSpringExecutor.class);
 
+    private final boolean atOnceStart;
+
+    public XxlJobSpringExecutor() {
+        this(true);
+    }
+
+    public XxlJobSpringExecutor(boolean atOnceStart) {
+        this.atOnceStart = atOnceStart;
+    }
 
     // start
     @Override
@@ -41,10 +50,12 @@ public class XxlJobSpringExecutor extends XxlJobExecutor implements ApplicationC
         GlueFactory.refreshInstance(1);
 
         // super start
-        try {
-            super.start();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+        if (atOnceStart) {
+            try {
+                super.start();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
         }
     }
 


### PR DESCRIPTION
在某些客户端有自己的初始化逻辑的时候，在客户端未完成初始化动作时，XxlJobSpringExecutor可能就已经完成了执行器注册，进而可能导致某些依赖客户端初始化的任务执行失败，增加一个控制字段，可以在必要的时候让用户自己选择start时机