### PR TITLE
[CI]增加发版时自动推送docker image流水线

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,47 @@
+name: Publish Admin Docker image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+        - name: Check out the repo
+          uses: actions/checkout@v4
+
+        - name: Set up JDK 1.8
+          uses: actions/setup-java@v1
+          with:
+            java-version: 1.8
+
+        - name: Build with Maven
+          run: mvn -B package --file pom.xml
+
+        - name: Docker meta
+          id: meta
+          uses: docker/metadata-action@v5
+          with:
+            images: xuxueli/xxl-job-admin
+
+        - name: Login to Docker Hub
+          uses: docker/login-action@v3
+          with:
+            username: ${{ secrets.DOCKERHUB_USERNAME }}
+            password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+        - name: Build and push Docker image
+          id: push
+          uses: docker/build-push-action@v5
+          with:
+            context: ./xxl-job-admin
+            file: ./xxl-job-admin/Dockerfile
+            push: true
+            tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
- [ ] Other : [CI]增加发版时自动推送docker image流水线

**The description of the PR:**
dockerhub上目前不存在latest版本的image，导致拉取时必须要指定版本
```
root@10-7-154-170:~# docker pull xuxueli/xxl-job-admin
Using default tag: latest
Error response from daemon: manifest for xuxueli/xxl-job-admin:latest not found: manifest unknown: manifest unknown
root@10-7-154-170:~# 
```
创建release版本时，增加自动推动流水线的CI流程，镜像仓库已经改成`xuxueli/xxl-job-admin`
```
        - name: Docker meta
          id: meta
          uses: docker/metadata-action@v5
          with:
            images: xuxueli/xxl-job-admin
```
**特别注意**，需要在仓库的`Settings - Secrets and variables - Actions - Repository secrets`中定义`DOCKERHUB_USERNAME`及`DOCKERHUB_TOKEN`的值
```
        - name: Login to Docker Hub
          uses: docker/login-action@v3
          with:
            username: ${{ secrets.DOCKERHUB_USERNAME }}
            password: ${{ secrets.DOCKERHUB_TOKEN }}
```