### PR TITLE
华为云容器动态化部署时，admin服务出现历史日志无法查询问题修改

### DIFF
--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/controller/JobLogController.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/controller/JobLogController.java
@@ -1,6 +1,7 @@
 package com.xxl.job.admin.controller;
 
 import com.xxl.job.admin.core.complete.XxlJobCompleter;
+import com.xxl.job.admin.core.entity.ExecutorAddressStatic;
 import com.xxl.job.admin.core.exception.XxlJobException;
 import com.xxl.job.admin.core.model.XxlJobGroup;
 import com.xxl.job.admin.core.model.XxlJobInfo;
@@ -146,7 +147,10 @@ public class JobLogController {
 			}
 
 			// log cat
-			ExecutorBiz executorBiz = XxlJobScheduler.getExecutorBiz(jobLog.getExecutorAddress());
+			//场景：docker容器化动态部署。容器中日志存储路径挂载于宿主机，且容器当重启执行器服务时，会动态化更换随机容器，执行器ip会变更，自动获取的ip为当前执行器的docker实例ip（192.*.*.*网段）
+			// 。容器互通，但容器无法访问其他容器的192网段地址，此处查询数据库日志表执行器字段，会出现历史日志无法访问的问题。所以在此，将访问地址替换为执行器传过来的执行地址。
+			logger.info("==============>logDetailCat执行器地址为: " + ExecutorAddressStatic.executorAddress);
+			ExecutorBiz executorBiz = XxlJobScheduler.getExecutorBiz(ExecutorAddressStatic.executorAddress);
 			ReturnT<LogResult> logResult = executorBiz.log(new LogParam(jobLog.getTriggerTime().getTime(), logId, fromLineNum));
 
 			// is end

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/entity/ExecutorAddressStatic.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/entity/ExecutorAddressStatic.java
@@ -1,0 +1,7 @@
+package com.xxl.job.admin.core.entity;
+
+public class ExecutorAddressStatic {
+
+    public static String executorAddress;
+
+}

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/thread/JobRegistryHelper.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/thread/JobRegistryHelper.java
@@ -1,6 +1,7 @@
 package com.xxl.job.admin.core.thread;
 
 import com.xxl.job.admin.core.conf.XxlJobAdminConfig;
+import com.xxl.job.admin.core.entity.ExecutorAddressStatic;
 import com.xxl.job.admin.core.model.XxlJobGroup;
 import com.xxl.job.admin.core.model.XxlJobRegistry;
 import com.xxl.job.core.biz.model.RegistryParam;
@@ -166,6 +167,8 @@ public class JobRegistryHelper {
 					// fresh
 					freshGroupRegistryInfo(registryParam);
 				}
+				ExecutorAddressStatic.executorAddress = registryParam.getRegistryValue();
+				logger.info("=============>registry执行日志注册地址为：" + ExecutorAddressStatic.executorAddress);
 			}
 		});
 


### PR DESCRIPTION
- [ ] Bugfix


**The description of the PR:**
场景：华为云docker容器化动态部署。（服务启动时，会随机容器部署，ip节点动态变更）
情况描述：执行器服务在容器中日志存储路径挂载于宿主机(这样每个容器可以读取日志路径)，且容器当重启执行器服务时，会动态化更换随机容器，执行器ip会变更，自动获取的ip为当前执行器的docker实例ip（192.*.*.*网段）。容器互通，但容器无法访问其他容器的192网段地址，此处查询数据库日志表执行器字段，会出现历史日志无法访问的问题。所以在此，将访问地址替换为执行器传过来的执行地址。

**Other information:**
![image](https://github.com/user-attachments/assets/fe4ce71d-6298-419f-a5d9-353b836c5653)
![3e9c625d05d16f9c910f31072a023ceb](https://github.com/user-attachments/assets/c8e2dbf4-f374-4936-bd4a-eb07b95b6958)