### PR TITLE
fix(job-thread): add synchronized block to avoid repeat trigger job

### DIFF
--- a/xxl-job-core/src/main/java/com/xxl/job/core/thread/JobThread.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/thread/JobThread.java
@@ -59,13 +59,14 @@ public class JobThread extends Thread{
      * @return
      */
 	public ReturnT<String> pushTriggerQueue(TriggerParam triggerParam) {
-		// avoid repeat
-		if (triggerLogIdSet.contains(triggerParam.getLogId())) {
-			logger.info(">>>>>>>>>>> repeate trigger job, logId:{}", triggerParam.getLogId());
-			return new ReturnT<String>(ReturnT.FAIL_CODE, "repeate trigger job, logId:" + triggerParam.getLogId());
+        // avoid repeat
+		synchronized (this){
+			if (triggerLogIdSet.contains(triggerParam.getLogId())) {
+				logger.info(">>>>>>>>>>> repeate trigger job, logId:{}", triggerParam.getLogId());
+				return new ReturnT<String>(ReturnT.FAIL_CODE, "repeate trigger job, logId:" + triggerParam.getLogId());
+			}
+			triggerLogIdSet.add(triggerParam.getLogId());
 		}
-
-		triggerLogIdSet.add(triggerParam.getLogId());
 		triggerQueue.add(triggerParam);
         return ReturnT.SUCCESS;
 	}


### PR DESCRIPTION
Add synchronized block around triggerLogIdSet check and addition to ensure thread-safety and prevent repeated job triggers. This update modifies the JobThread class to handle concurrent access to triggerLogIdSet properly.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**
triggerLogIdSet.contains 和 triggerLogIdSet.add 两个操作之间可能存在竞态条件。也就是说，如果在检查 triggerLogIdSet.contains 之后，但在 triggerLogIdSet.add 之前，另一个线程插入了相同的 logId，那么 logId 就会被重复添加。这种情况在实际中可能会出现问题。

**Other information:**