### PR TITLE
Update XxlJobInfoMapper.xml（解决调度中心调度过程中停止的job启动问题）

### DIFF
--- a/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobInfoMapper.xml
+++ b/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobInfoMapper.xml
@@ -232,8 +232,7 @@
 		UPDATE xxl_job_info
 		SET
 			trigger_last_time = #{triggerLastTime},
-			trigger_next_time = #{triggerNextTime},
-			trigger_status = #{triggerStatus}
+			trigger_next_time = #{triggerNextTime}
 		WHERE id = #{id}
 	</update>
 


### PR DESCRIPTION
修复bug
服务端在执行调度器的时候，先将任务status为1的满足时间条件的定时任务取出，最终也会更新xxl_job_info的status状态。在这个中间时刻，我发出了关闭定时任务的请求，调度器后续的更新操作又会将xxl_job_info的status改为正常运行状态。

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**


**Other information:**