### PR TITLE
chore:增加手动注册的HTTP地址有效性校验

### DIFF
--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/controller/JobGroupController.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/controller/JobGroupController.java
@@ -47,7 +47,6 @@ public class JobGroupController {
 										@RequestParam(required = false, defaultValue = "0") int start,
 										@RequestParam(required = false, defaultValue = "10") int length,
 										String appname, String title) {
-
 		// page query
 		List<XxlJobGroup> list = xxlJobGroupDao.pageList(start, length, appname, title);
 		int list_count = xxlJobGroupDao.pageListCount(start, length, appname, title);
@@ -141,6 +140,10 @@ public class JobGroupController {
 				if (item==null || item.trim().length()==0) {
 					return new ReturnT<String>(500, I18nUtil.getString("jobgroup_field_registryList_unvalid") );
 				}
+				String url = item.trim().toLowerCase();
+				if (!isHttpAddressValid(url)){
+					return new ReturnT<String>(500, I18nUtil.getString("jobgroup_field_registryList_unvalid") );
+				}
 			}
 		}
 
@@ -149,6 +152,19 @@ public class JobGroupController {
 
 		int ret = xxlJobGroupDao.update(xxlJobGroup);
 		return (ret>0)?ReturnT.SUCCESS:ReturnT.FAIL;
+	}
+
+	// valid http address
+	private boolean isHttpAddressValid(String url){
+		if (url == null){
+			return false;
+		}
+
+		// valid
+		if(!url.startsWith("http://") && !url.startsWith("https://") && url.contains(" ")){
+			return false;
+		}
+		return true;
 	}
 
 	private List<String> findRegistryByAppName(String appnameParam){


### PR DESCRIPTION
问题描述：当对执行器进行手动注册的时候，缺乏简单的HTTP地址合法校验，会导致后续事件调用的失败。
解决方案：先把url进行前后缀空格去除，然后把它变成小写，进行下一步验证。
验证思路(若url不含有http://，不含有https://，含有空格，则说明该url为不合法。)
`
if(!url.startsWith("http://") && !url.startsWith("https://") && url.contains(" ")){
	return false;
}
`
当然这里只是提供了较为简单的合法性校验，同时我觉得也是必要的，因为当用户进行手动注册时若没有符合相应规则，则对后续的调用失败。
如下为修改前后的图片信息：
[XXL-JOB开源.docx](https://github.com/user-attachments/files/17614400/XXL-JOB.docx)
