### PR TITLE
feat 可配置化预读时间

### DIFF
--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/conf/XxlJobAdminConfig.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/conf/XxlJobAdminConfig.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 import javax.annotation.Resource;
 import javax.sql.DataSource;
 import java.util.Arrays;
+import java.util.Optional;
 
 /**
  * xxl-job config
@@ -67,6 +68,9 @@ public class XxlJobAdminConfig implements InitializingBean, DisposableBean {
     @Value("${xxl.job.logretentiondays}")
     private int logretentiondays;
 
+    @Value("${xxl.job.pre-read-ms}")
+    private long preReadMs;
+
     // dao, service
 
     @Resource
@@ -121,6 +125,10 @@ public class XxlJobAdminConfig implements InitializingBean, DisposableBean {
             return -1;  // Limit greater than or equal to 7, otherwise close
         }
         return logretentiondays;
+    }
+
+    public long getPreReadMs() {
+        return Optional.ofNullable(preReadMs).orElse(5000l);
     }
 
     public XxlJobLogDao getXxlJobLogDao() {

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/service/impl/XxlJobServiceImpl.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/service/impl/XxlJobServiceImpl.java
@@ -1,5 +1,6 @@
 package com.xxl.job.admin.service.impl;
 
+import com.xxl.job.admin.core.conf.XxlJobAdminConfig;
 import com.xxl.job.admin.core.cron.CronExpression;
 import com.xxl.job.admin.core.model.XxlJobGroup;
 import com.xxl.job.admin.core.model.XxlJobInfo;
@@ -264,7 +265,7 @@ public class XxlJobServiceImpl implements XxlJobService {
 		boolean scheduleDataNotChanged = jobInfo.getScheduleType().equals(exists_jobInfo.getScheduleType()) && jobInfo.getScheduleConf().equals(exists_jobInfo.getScheduleConf());
 		if (exists_jobInfo.getTriggerStatus() == 1 && !scheduleDataNotChanged) {
 			try {
-				Date nextValidTime = JobScheduleHelper.generateNextValidTime(jobInfo, new Date(System.currentTimeMillis() + JobScheduleHelper.PRE_READ_MS));
+				Date nextValidTime = JobScheduleHelper.generateNextValidTime(jobInfo, new Date(System.currentTimeMillis() + XxlJobAdminConfig.getAdminConfig().getPreReadMs()));
 				if (nextValidTime == null) {
 					return new ReturnT<String>(ReturnT.FAIL_CODE, (I18nUtil.getString("schedule_type")+I18nUtil.getString("system_unvalid")) );
 				}
@@ -324,7 +325,7 @@ public class XxlJobServiceImpl implements XxlJobService {
 		// next trigger time (5s后生效，避开预读周期)
 		long nextTriggerTime = 0;
 		try {
-			Date nextValidTime = JobScheduleHelper.generateNextValidTime(xxlJobInfo, new Date(System.currentTimeMillis() + JobScheduleHelper.PRE_READ_MS));
+			Date nextValidTime = JobScheduleHelper.generateNextValidTime(xxlJobInfo, new Date(System.currentTimeMillis() + XxlJobAdminConfig.getAdminConfig().getPreReadMs()));
 			if (nextValidTime == null) {
 				return new ReturnT<String>(ReturnT.FAIL_CODE, (I18nUtil.getString("schedule_type")+I18nUtil.getString("system_unvalid")) );
 			}

--- a/xxl-job-admin/src/main/resources/application.properties
+++ b/xxl-job-admin/src/main/resources/application.properties
@@ -64,3 +64,6 @@ xxl.job.triggerpool.slow.max=100
 
 ### xxl-job, log retention days
 xxl.job.logretentiondays=30
+
+### xxl-job, other
+xxl.job.pre-read-ms=5000


### PR DESCRIPTION
无需代码层面改动，即可实现时间轮预读范围修改，支持平滑升级，缺省处理逻辑与``XxlJobAdminConfig``其他参数保持一致，默认值保持不变。

1. 自由调整范围，控制性能开销。
2. 当前默认值5000ms情况下，新增5s内的任务并启动会提示调度类型非法，调降预读范围可提高动态任务自由度。