### PR TITLE
解决调度中心调度过程中在后台停止的job被错误启动问题（优化方案）

### DIFF
--- a/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobInfoMapper.xml
+++ b/xxl-job-admin/src/main/resources/mybatis-mapper/XxlJobInfoMapper.xml
@@ -232,8 +232,10 @@
 		UPDATE xxl_job_info
 		SET
 			trigger_last_time = #{triggerLastTime},
-			trigger_next_time = #{triggerNextTime},
-			trigger_status = #{triggerStatus}
+			trigger_next_time = #{triggerNextTime}
+			<if test="triggerStatus == 0">
+			 , trigger_status = #{triggerStatus}
+			</if>
 		WHERE id = #{id}
 		  AND trigger_status = 1
 	</update>


### PR DESCRIPTION
解决调度过程中错误启动后台停止的任务bug

[√ ] Bugfix
这个是refreshNextValidTime的逻辑
```Java
private void refreshNextValidTime(XxlJobInfo jobInfo, Date fromTime) throws Exception {
        Date nextValidTime = generateNextValidTime(jobInfo, fromTime);
        if (nextValidTime != null) {
            jobInfo.setTriggerLastTime(jobInfo.getTriggerNextTime());
            jobInfo.setTriggerNextTime(nextValidTime.getTime());
        } else {
            jobInfo.setTriggerStatus(0);
            jobInfo.setTriggerLastTime(0);
            jobInfo.setTriggerNextTime(0);
            logger.warn(">>>>>>>>>>> xxl-job, refreshNextValidTime fail for job: jobId={}, scheduleType={}, scheduleConf={}",
                    jobInfo.getId(), jobInfo.getScheduleType(), jobInfo.getScheduleConf());
        }
    }
```
在nextValidTime 为null的时候会设置调度状态为0，其它情况下SQL中都是设置为上次查询到的状态，这是不安全的如果在这期间我在后台把任务停了，那么这个SQL还是会把任务重新启动起来，如果想让这里的 jobInfo.setTriggerStatus(0);生效的话可以在xml问句中加一个==0的判断安全一下，因为代码调度过程中只可能把调度状态设置为0，scheduleUpdate方法只有调度这里在用，改了不会影响其它的，望采纳。