### PR TITLE
调整执行一次时任务描述的显示，更清晰的知道执行一次是执行的哪个任务

### DIFF
--- a/xxl-job-admin/src/main/resources/static/js/jobinfo.index.1.js
+++ b/xxl-job-admin/src/main/resources/static/js/jobinfo.index.1.js
@@ -266,6 +266,7 @@ $(function() {
 
         $("#jobTriggerModal .form input[name='id']").val( row.id );
         $("#jobTriggerModal .form textarea[name='executorParam']").val( row.executorParam );
+		$("#jobTriggerModal .modal-title span[name='jobDesc']").text( row.jobDesc );
 
         $('#jobTriggerModal').modal({backdrop: false, keyboard: false}).modal('show');
     });

--- a/xxl-job-admin/src/main/resources/templates/jobinfo/jobinfo.index.ftl
+++ b/xxl-job-admin/src/main/resources/templates/jobinfo/jobinfo.index.ftl
@@ -497,7 +497,11 @@ exit 0
     <div class="modal-dialog ">
         <div class="modal-content">
             <div class="modal-header">
-                <h4 class="modal-title" >${I18n.jobinfo_opt_run}</h4>
+                <h4 class="modal-title" >
+                    <span>${I18n.jobinfo_opt_run}</span>
+                    <span>：</span>
+                    <span name="jobDesc"></span>
+                </h4>
             </div>
             <div class="modal-body">
                 <form class="form-horizontal form" role="form" >


### PR DESCRIPTION
当任务较多，同时执行参数也差不多时，手动执行一次时，无法清晰的看到具体对应哪个任务。
调整前：
![执行一次前](https://github.com/user-attachments/assets/f379f6e9-1c00-49ca-b386-671417a51166)
调整后：
![执行一次后](https://github.com/user-attachments/assets/4b5eac91-d15a-4b48-a29d-4c02530ac374)
