### PR TITLE
给httpJobHandler的参数传入添加登录验证功能

### DIFF
--- a/xxl-job-executor-samples/xxl-job-executor-sample-springboot/src/main/java/com/xxl/job/executor/service/jobhandler/SampleXxlJob.java
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-springboot/src/main/java/com/xxl/job/executor/service/jobhandler/SampleXxlJob.java
@@ -158,11 +158,13 @@ public class SampleXxlJob {
         String url;
         String method;
         String data;
+        String auth;
         try {
             Map<String, String> paramMap =GsonTool.fromJson(param, Map.class);
             url = paramMap.get("url");
             method = paramMap.get("method");
             data = paramMap.get("data");
+            auth = paramMap.get("auth");
         } catch (Exception e) {
             XxlJobHelper.log(e);
             XxlJobHelper.handleFail();
@@ -203,7 +205,10 @@ public class SampleXxlJob {
             connection.setRequestProperty("connection", "Keep-Alive");
             connection.setRequestProperty("Content-Type", "application/json;charset=UTF-8");
             connection.setRequestProperty("Accept-Charset", "application/json;charset=UTF-8");
-
+            if (auth != null) {
+            connection.setRequestProperty("Authorization", "Basic " + auth);
+            }
+            
             // do connection
             connection.connect();
 


### PR DESCRIPTION
新增功能，
给httpJobHandler的参数传入添加登录验证功能。
传入字符串 username:password  使用base64编码后的内容。