### PR TITLE
解决mac电脑maven打包后，启动成功但访问报错问题

### DIFF
--- a/xxl-job-admin/pom.xml
+++ b/xxl-job-admin/pom.xml
@@ -84,7 +84,7 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				<!--<version>${spring-boot.version}</version>-->
+				<version>${spring-boot.version}</version>
 				<executions>
 					<execution>
 						<goals>

--- a/xxl-job-executor-samples/xxl-job-executor-sample-springboot/pom.xml
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-springboot/pom.xml
@@ -58,7 +58,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <!--<version>${spring-boot.version}</version>-->
+                <version>${spring-boot.version}</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
- [ ] Bugfix
IDEA启动访问都正常，但mac电脑maven打包后，启动成功但访问前端页面报错
I18nUtil [in template "common/common.macro.ftl

