### PR TITLE
【refactor】 simplify transaction logic in JobScheduleHelper

### DIFF
--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/thread/JobScheduleHelper.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/thread/JobScheduleHelper.java
@@ -6,6 +6,7 @@ import com.xxl.job.admin.core.model.XxlJobInfo;
 import com.xxl.job.admin.core.scheduler.MisfireStrategyEnum;
 import com.xxl.job.admin.core.scheduler.ScheduleTypeEnum;
 import com.xxl.job.admin.core.trigger.TriggerTypeEnum;
+import com.xxl.job.admin.core.util.DBHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,6 +15,7 @@ import java.sql.PreparedStatement;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * @author xuxueli 2019-05-21
@@ -58,147 +60,99 @@ public class JobScheduleHelper {
                     // Scan Job
                     long start = System.currentTimeMillis();
 
-                    Connection conn = null;
-                    Boolean connAutoCommit = null;
-                    PreparedStatement preparedStatement = null;
-
-                    boolean preReadSuc = true;
+                    AtomicBoolean preReadSuc = new AtomicBoolean(true);
                     try {
-
-                        conn = XxlJobAdminConfig.getAdminConfig().getDataSource().getConnection();
-                        connAutoCommit = conn.getAutoCommit();
-                        conn.setAutoCommit(false);
-
-                        preparedStatement = conn.prepareStatement(  "select * from xxl_job_lock where lock_name = 'schedule_lock' for update" );
-                        preparedStatement.execute();
-
                         // tx start
+                      DBHelper.withTransaction(XxlJobAdminConfig.getAdminConfig().getDataSource(), conn -> {
+                          try(PreparedStatement preparedStatement = conn.prepareStatement("select * from xxl_job_lock where lock_name = 'schedule_lock' for update")) {
+                              preparedStatement.execute();
+                          }
+                          // 1、pre read
+                          long nowTime = System.currentTimeMillis();
+                          List<XxlJobInfo> scheduleList = XxlJobAdminConfig.getAdminConfig().getXxlJobInfoDao().scheduleJobQuery(nowTime + PRE_READ_MS, preReadCount);
+                          if (scheduleList!=null && scheduleList.size()>0) {
+                              // 2、push time-ring
+                              for (XxlJobInfo jobInfo: scheduleList) {
 
-                        // 1、pre read
-                        long nowTime = System.currentTimeMillis();
-                        List<XxlJobInfo> scheduleList = XxlJobAdminConfig.getAdminConfig().getXxlJobInfoDao().scheduleJobQuery(nowTime + PRE_READ_MS, preReadCount);
-                        if (scheduleList!=null && scheduleList.size()>0) {
-                            // 2、push time-ring
-                            for (XxlJobInfo jobInfo: scheduleList) {
+                                  // time-ring jump
+                                  if (nowTime > jobInfo.getTriggerNextTime() + PRE_READ_MS) {
+                                      // 2.1、trigger-expire > 5s：pass && make next-trigger-time
+                                      logger.warn(">>>>>>>>>>> xxl-job, schedule misfire, jobId = " + jobInfo.getId());
 
-                                // time-ring jump
-                                if (nowTime > jobInfo.getTriggerNextTime() + PRE_READ_MS) {
-                                    // 2.1、trigger-expire > 5s：pass && make next-trigger-time
-                                    logger.warn(">>>>>>>>>>> xxl-job, schedule misfire, jobId = " + jobInfo.getId());
+                                      // 1、misfire match
+                                      MisfireStrategyEnum misfireStrategyEnum = MisfireStrategyEnum.match(jobInfo.getMisfireStrategy(), MisfireStrategyEnum.DO_NOTHING);
+                                      if (MisfireStrategyEnum.FIRE_ONCE_NOW == misfireStrategyEnum) {
+                                          // FIRE_ONCE_NOW 》 trigger
+                                          JobTriggerPoolHelper.trigger(jobInfo.getId(), TriggerTypeEnum.MISFIRE, -1, null, null, null);
+                                          logger.debug(">>>>>>>>>>> xxl-job, schedule push trigger : jobId = " + jobInfo.getId() );
+                                      }
 
-                                    // 1、misfire match
-                                    MisfireStrategyEnum misfireStrategyEnum = MisfireStrategyEnum.match(jobInfo.getMisfireStrategy(), MisfireStrategyEnum.DO_NOTHING);
-                                    if (MisfireStrategyEnum.FIRE_ONCE_NOW == misfireStrategyEnum) {
-                                        // FIRE_ONCE_NOW 》 trigger
-                                        JobTriggerPoolHelper.trigger(jobInfo.getId(), TriggerTypeEnum.MISFIRE, -1, null, null, null);
-                                        logger.debug(">>>>>>>>>>> xxl-job, schedule push trigger : jobId = " + jobInfo.getId() );
-                                    }
+                                      // 2、fresh next
+                                      refreshNextValidTime(jobInfo, new Date());
 
-                                    // 2、fresh next
-                                    refreshNextValidTime(jobInfo, new Date());
+                                  } else if (nowTime > jobInfo.getTriggerNextTime()) {
+                                      // 2.2、trigger-expire < 5s：direct-trigger && make next-trigger-time
 
-                                } else if (nowTime > jobInfo.getTriggerNextTime()) {
-                                    // 2.2、trigger-expire < 5s：direct-trigger && make next-trigger-time
+                                      // 1、trigger
+                                      JobTriggerPoolHelper.trigger(jobInfo.getId(), TriggerTypeEnum.CRON, -1, null, null, null);
+                                      logger.debug(">>>>>>>>>>> xxl-job, schedule push trigger : jobId = " + jobInfo.getId() );
 
-                                    // 1、trigger
-                                    JobTriggerPoolHelper.trigger(jobInfo.getId(), TriggerTypeEnum.CRON, -1, null, null, null);
-                                    logger.debug(">>>>>>>>>>> xxl-job, schedule push trigger : jobId = " + jobInfo.getId() );
+                                      // 2、fresh next
+                                      refreshNextValidTime(jobInfo, new Date());
 
-                                    // 2、fresh next
-                                    refreshNextValidTime(jobInfo, new Date());
+                                      // next-trigger-time in 5s, pre-read again
+                                      if (jobInfo.getTriggerStatus()==1 && nowTime + PRE_READ_MS > jobInfo.getTriggerNextTime()) {
 
-                                    // next-trigger-time in 5s, pre-read again
-                                    if (jobInfo.getTriggerStatus()==1 && nowTime + PRE_READ_MS > jobInfo.getTriggerNextTime()) {
+                                          // 1、make ring second
+                                          int ringSecond = (int)((jobInfo.getTriggerNextTime()/1000)%60);
 
-                                        // 1、make ring second
-                                        int ringSecond = (int)((jobInfo.getTriggerNextTime()/1000)%60);
+                                          // 2、push time ring
+                                          pushTimeRing(ringSecond, jobInfo.getId());
 
-                                        // 2、push time ring
-                                        pushTimeRing(ringSecond, jobInfo.getId());
+                                          // 3、fresh next
+                                          refreshNextValidTime(jobInfo, new Date(jobInfo.getTriggerNextTime()));
 
-                                        // 3、fresh next
-                                        refreshNextValidTime(jobInfo, new Date(jobInfo.getTriggerNextTime()));
+                                      }
 
-                                    }
+                                  } else {
+                                      // 2.3、trigger-pre-read：time-ring trigger && make next-trigger-time
 
-                                } else {
-                                    // 2.3、trigger-pre-read：time-ring trigger && make next-trigger-time
+                                      // 1、make ring second
+                                      int ringSecond = (int)((jobInfo.getTriggerNextTime()/1000)%60);
 
-                                    // 1、make ring second
-                                    int ringSecond = (int)((jobInfo.getTriggerNextTime()/1000)%60);
+                                      // 2、push time ring
+                                      pushTimeRing(ringSecond, jobInfo.getId());
 
-                                    // 2、push time ring
-                                    pushTimeRing(ringSecond, jobInfo.getId());
+                                      // 3、fresh next
+                                      refreshNextValidTime(jobInfo, new Date(jobInfo.getTriggerNextTime()));
 
-                                    // 3、fresh next
-                                    refreshNextValidTime(jobInfo, new Date(jobInfo.getTriggerNextTime()));
+                                  }
 
-                                }
+                              }
 
-                            }
+                              // 3、update trigger info
+                              for (XxlJobInfo jobInfo: scheduleList) {
+                                  XxlJobAdminConfig.getAdminConfig().getXxlJobInfoDao().scheduleUpdate(jobInfo);
+                              }
 
-                            // 3、update trigger info
-                            for (XxlJobInfo jobInfo: scheduleList) {
-                                XxlJobAdminConfig.getAdminConfig().getXxlJobInfoDao().scheduleUpdate(jobInfo);
-                            }
+                          } else {
+                              preReadSuc.set(false);
+                          }
 
-                        } else {
-                            preReadSuc = false;
-                        }
-
-                        // tx stop
-
+                          // tx stop
+                      }, scheduleThreadToStop, e -> logger.error(">>>>>>>>>>> xxl-job, scheduleThread error:", e));
 
                     } catch (Throwable e) {
                         if (!scheduleThreadToStop) {
                             logger.error(">>>>>>>>>>> xxl-job, JobScheduleHelper#scheduleThread error:{}", e);
                         }
-                    } finally {
-
-                        // commit
-                        if (conn != null) {
-                            try {
-                                conn.commit();
-                            } catch (Throwable e) {
-                                if (!scheduleThreadToStop) {
-                                    logger.error(e.getMessage(), e);
-                                }
-                            }
-                            try {
-                                conn.setAutoCommit(connAutoCommit);
-                            } catch (Throwable e) {
-                                if (!scheduleThreadToStop) {
-                                    logger.error(e.getMessage(), e);
-                                }
-                            }
-                            try {
-                                conn.close();
-                            } catch (Throwable e) {
-                                if (!scheduleThreadToStop) {
-                                    logger.error(e.getMessage(), e);
-                                }
-                            }
-                        }
-
-                        // close PreparedStatement
-                        if (null != preparedStatement) {
-                            try {
-                                preparedStatement.close();
-                            } catch (Throwable e) {
-                                if (!scheduleThreadToStop) {
-                                    logger.error(e.getMessage(), e);
-                                }
-                            }
-                        }
                     }
                     long cost = System.currentTimeMillis()-start;
-
-
                     // Wait seconds, align second
                     if (cost < 1000) {  // scan-overtime, not wait
                         try {
                             // pre-read period: success > scan each second; fail > skip this period;
-                            TimeUnit.MILLISECONDS.sleep((preReadSuc?1000:PRE_READ_MS) - System.currentTimeMillis()%1000);
+                            TimeUnit.MILLISECONDS.sleep((preReadSuc.get()?1000:PRE_READ_MS) - System.currentTimeMillis()%1000);
                         } catch (Throwable e) {
                             if (!scheduleThreadToStop) {
                                 logger.error(e.getMessage(), e);

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/util/DBHelper.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/util/DBHelper.java
@@ -1,0 +1,41 @@
+package com.xxl.job.admin.core.util;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.util.function.Consumer;
+
+/**
+ * @author: donglingmo
+ * Date: 2025/4/14
+ * Description:
+ */
+public class DBHelper {
+    @FunctionalInterface
+    public interface SqlConsumer {
+        void accept(Connection conn) throws Exception;
+    }
+
+    public static void withTransaction(DataSource ds, SqlConsumer consumer, boolean suppressLog, Consumer<Throwable> onError) {
+        try (Connection conn = ds.getConnection()) {
+            boolean originalAutoCommit = conn.getAutoCommit();
+            try {
+                conn.setAutoCommit(false);
+                consumer.accept(conn);
+                conn.commit();
+            } catch (Exception e) {
+                conn.rollback();
+                if (!suppressLog) {
+                    onError.accept(e);
+                }
+                throw e;
+            } finally {
+                conn.setAutoCommit(originalAutoCommit);
+            }
+        } catch (Exception e) {
+            if (!suppressLog) {
+                onError.accept(e);
+            }
+            throw new RuntimeException("DB transaction failed", e);
+        }
+    }
+}


### PR DESCRIPTION
重构JobScheduleHelper中的事务处理逻辑，封装为统一的DbHelper工具类，使用try-with-resources自动关闭资源，提升调度模块整体健壮性和代码整洁度。