### PR TITLE
fix: close DataOutputStream in finally block for resource safety in postBody

### DIFF
--- a/xxl-job-core/src/main/java/com/xxl/job/core/util/XxlJobRemotingUtil.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/util/XxlJobRemotingUtil.java
@@ -68,6 +68,7 @@ public class XxlJobRemotingUtil {
     public static ReturnT postBody(String url, String accessToken, int timeout, Object requestObj, Class returnTargClassOfT) {
         HttpURLConnection connection = null;
         BufferedReader bufferedReader = null;
+        DataOutputStream dataOutputStream = null;
         try {
             // connection
             URL realUrl = new URL(url);
@@ -102,7 +103,7 @@ public class XxlJobRemotingUtil {
             if (requestObj != null) {
                 String requestBody = GsonTool.toJson(requestObj);
 
-                DataOutputStream dataOutputStream = new DataOutputStream(connection.getOutputStream());
+                dataOutputStream = new DataOutputStream(connection.getOutputStream());
                 dataOutputStream.write(requestBody.getBytes("UTF-8"));
                 dataOutputStream.flush();
                 dataOutputStream.close();
@@ -144,6 +145,9 @@ public class XxlJobRemotingUtil {
             return new ReturnT<String>(ReturnT.FAIL_CODE, "xxl-job remoting error("+ e.getMessage() +"), for url : " + url);
         } finally {
             try {
+                if (dataOutputStream != null) {
+                    dataOutputStream.close();
+                }
                 if (bufferedReader != null) {
                     bufferedReader.close();
                 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**
This PR fixes a potential resource leak in the postBody method of XxlJobRemotingUtil.

Previously, only bufferedReader and connection were closed in the finally block, while DataOutputStream was closed inside the try block.
If an exception occurred during writing the request body, the stream might not have been closed, causing a resource leak.

To ensure consistent and safe resource management, the closing of DataOutputStream has been moved to the finally block, along with the other resources.
Now, all resources used in postBody are properly closed, even in the event of an exception.

**Other information:**



Thank you for reviewing!