### PR TITLE
xxl-job-core 模块打包指定 1.8 版本，使得 jdk8 的客户端应用可以使用3.x版本包

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,8 @@
 		<maven.compiler.encoding>UTF-8</maven.compiler.encoding>
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.compiler.target>17</maven.compiler.target>
+		<client.maven.compiler.source>1.8</client.maven.compiler.source>
+		<client.maven.compiler.target>1.8</client.maven.compiler.target>
 		<maven.test.skip>true</maven.test.skip>
 		<!-- plugin -->
 		<maven-source-plugin.version>3.3.1</maven-source-plugin.version>

--- a/xxl-job-core/pom.xml
+++ b/xxl-job-core/pom.xml
@@ -13,6 +13,11 @@
 	<description>A distributed task scheduling framework.</description>
 	<url>https://www.xuxueli.com/</url>
 
+	<properties>
+		<maven.compiler.source>${client.maven.compiler.source}</maven.compiler.source>
+		<maven.compiler.target>${client.maven.compiler.target}</maven.compiler.target>
+	</properties>
+
 	<dependencies>
 
 		<!-- ********************** embed server: netty + gson ********************** -->


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**

客户端接入 3.1.1 的 xxl-job-core 包时提示：`类文件具有错误的版本 61.0, 应为 52.0` 

这个是因为 xxl-job 在 3.x 中升级到了 JDK 17，对于接入的客户端来说很多还都是 1.8 版本，且也没有强制升级的必要；

所以这个 pr 修改 xxl-job-core 包打包时 maven 源码和目标版本为 1.8

参考：nacos 在新版本中也是服务端运行 要求 JDK17，client 要求 1.8 https://github.com/alibaba/nacos/blob/develop/pom.xml
**Other information:**