### PR TITLE
feat: Selected lasted JobGroup when user swap jobLog or jobInfo page.

### DIFF
--- a/xxl-job-admin/src/main/resources/static/js/jobinfo.index.1.js
+++ b/xxl-job-admin/src/main/resources/static/js/jobinfo.index.1.js
@@ -203,7 +203,8 @@ $(function() {
         //reload
         var jobGroup = $('#jobGroup').val();
         window.location.href = base_url + "/jobinfo?jobGroup=" + jobGroup;
-    });
+		localStorage.setItem("jobGroup.value",jobGroup)
+	});
 
 	// job operate
 	$("#job_list").on('click', '.job_operate',function() {
@@ -735,5 +736,9 @@ $(function() {
 		// show
 		$('#addModal').modal({backdrop: false, keyboard: false}).modal('show');
 	});
+
+	// save lasted jobGroup
+	$("#jobGroup").find("option[value='" + localStorage.getItem("jobGroup.value") + "']").attr("selected",true);
+
 
 });

--- a/xxl-job-admin/src/main/resources/static/js/joblog.index.1.js
+++ b/xxl-job-admin/src/main/resources/static/js/joblog.index.1.js
@@ -72,7 +72,7 @@ $(function() {
 	// init date tables
 	var logTable = $("#joblog_list").dataTable({
 		"deferRender": true,
-		"processing" : true, 
+		"processing" : true,
 	    "serverSide": true,
 		"ajax": {
 	        url: base_url + "/joblog/pageList" ,
@@ -141,7 +141,7 @@ $(function() {
 							return data?'<a class="logTips" href="javascript:;" >'+ I18n.system_show +'<span style="display:none;">'+ data +'</span></a>':I18n.system_empty;
 						}
 					},
-	                { 
+	                {
 	                	"data": 'handleTime',
                         "width":'20%',
 	                	"render": function ( data, type, row ) {
@@ -165,7 +165,7 @@ $(function() {
                             return html;
 						}
 	                },
-	                { 
+	                {
 	                	"data": 'handleMsg',
                         "width":'10%',
 	                	"render": function ( data, type, row ) {
@@ -207,7 +207,7 @@ $(function() {
 
 		                			return html;
 		                		}
-		                		return null;	
+		                		return null;
 	                		}
 	                	}
 	                }
@@ -242,22 +242,22 @@ $(function() {
             layer.msg( json.msg || I18n.system_api_error );
         }
     });
-	
+
 	// logTips alert
 	$('#joblog_list').on('click', '.logTips', function(){
 		var msg = $(this).find('span').html();
 		ComAlertTec.show(msg);
 	});
-	
+
 	// search Btn
 	$('#searchBtn').on('click', function(){
 		logTable.fnDraw();
 	});
-	
+
 	// logDetail look
 	$('#joblog_list').on('click', '.logDetail', function(){
 		var _id = $(this).attr('_id');
-		
+
 		window.open(base_url + '/joblog/logDetailPage?id=' + _id);
 		return;
 	});
@@ -351,6 +351,14 @@ $(function() {
 	$("#clearLogModal").on('hide.bs.modal', function () {
 		$("#clearLogModal .form")[0].reset();
 	});
+
+	// save lasted jobGroup
+	$('#jobGroup').on('change', function(){
+		var jobGroup = $('#jobGroup').val();
+		localStorage.setItem("jobGroup.value",jobGroup)
+	});
+	// show lasted jobGroup
+	$("#jobGroup").find("option[value='" + localStorage.getItem("jobGroup.value") + "']").attr("selected",true);
 
 });
 


### PR DESCRIPTION
## "Scheduling Log" in the navigation, locate the currently selected executor instead of clearing it (PS: This is convenient to use when there are hundreds or thousands of task executors, avoiding the need to scroll down and re-enter)

## 小优化：导航切换"任务管理和"调度日志"时, 定位当前选择的执行器，而不是清空（PS 在任务执行器 成百上千时 方便使用，避免下拉重新输入 )

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

<img width="1180" height="432" alt="8edab5d3_1553796" src="https://github.com/user-attachments/assets/c4084c1b-dec4-4d35-85c2-1efff21e3a25" />

**The description of the PR:**


**Other information:**