### PR TITLE
支持执行器通过XxlJobHelper或XxlJobContext获取job的触发时间戳

### DIFF
--- a/xxl-job-core/src/main/java/com/xxl/job/core/context/XxlJobContext.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/context/XxlJobContext.java
@@ -31,6 +31,11 @@ public class XxlJobContext {
      */
     private final String jobLogFileName;
 
+    /**
+     * log date time
+     */
+    private final long logDateTime;
+
     // ---------------------- for shard ----------------------
 
     /**
@@ -61,10 +66,11 @@ public class XxlJobContext {
     private String handleMsg;
 
 
-    public XxlJobContext(long jobId, String jobParam, String jobLogFileName, int shardIndex, int shardTotal) {
+    public XxlJobContext(long jobId, String jobParam, String jobLogFileName, long logDateTime, int shardIndex, int shardTotal) {
         this.jobId = jobId;
         this.jobParam = jobParam;
         this.jobLogFileName = jobLogFileName;
+        this.logDateTime = logDateTime;
         this.shardIndex = shardIndex;
         this.shardTotal = shardTotal;
 
@@ -81,6 +87,10 @@ public class XxlJobContext {
 
     public String getJobLogFileName() {
         return jobLogFileName;
+    }
+
+    public long getLogDateTime() {
+        return logDateTime;
     }
 
     public int getShardIndex() {

--- a/xxl-job-core/src/main/java/com/xxl/job/core/context/XxlJobHelper.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/context/XxlJobHelper.java
@@ -64,6 +64,20 @@ public class XxlJobHelper {
         return xxlJobContext.getJobLogFileName();
     }
 
+    /**
+     * current LogDateTime
+     *
+     * @return logDateTime
+     */
+    public static long getLogDateTime() {
+        XxlJobContext xxlJobContext = XxlJobContext.getXxlJobContext();
+        if (xxlJobContext == null) {
+            return -1;
+        }
+
+        return xxlJobContext.getLogDateTime();
+    }
+
     // ---------------------- for shard ----------------------
 
     /**

--- a/xxl-job-core/src/main/java/com/xxl/job/core/thread/JobThread.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/thread/JobThread.java
@@ -122,6 +122,7 @@ public class JobThread extends Thread{
 							triggerParam.getJobId(),
 							triggerParam.getExecutorParams(),
 							logFileName,
+							triggerParam.getLogDateTime(),
 							triggerParam.getBroadcastIndex(),
 							triggerParam.getBroadcastTotal());
 

--- a/xxl-job-core/src/main/java/com/xxl/job/core/thread/TriggerCallbackThread.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/thread/TriggerCallbackThread.java
@@ -209,6 +209,7 @@ public class TriggerCallbackThread {
                     null,
                     logFileName,
                     -1,
+                    -1,
                     -1));
             XxlJobHelper.log(logContent);
         }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**
【背景】通过xxljob的分片广播特性加速生成数据，在某些业务场景下，仅靠计算分片信息（shardIndex和shardTotal）可能会容易产生分片数据倾斜（即一些分片实例很快执行完，而另一些却执行很慢）。比如业务方有一个t_task表，里面记录了一个个待执行的任务，但每一个t_task.id背后所需要执行的时间差异很大且不好预估（这取决于每个t_task.id背后各自所需的数据量）。

【思路】分片执行时，不依赖于shardIndex和shardTotal，而是改为使用一个带”执行版本”的乐观锁机制，且这个”执行版本“应该由xxljob-admin统一提供给各个执行器分片使用，每个分片实例都扫描每一个t_task记录，并以乐观锁的”抢占式+一次性“特性来执行。而这个统一的”执行版本“，最直观的一种实现方式就是使用由xxljob-admin触发作业时的时间戳（即：com.xxl.job.core.openapi.model.TriggerRequest#logDateTime）

【问题】当前最新版本的xxljob（2025.11.04的master分支），在com.xxl.job.core.context.XxlJobHelper和com.xxl.job.core.context.XxlJobContext中都没有提供获取触发该作业的时间戳。

本PR正是希望实现执行器获取job的触发时间戳的功能，请帮忙review一下代码，谢谢。

**Other information:**
相关Issue：[Issue-3481](https://github.com/xuxueli/xxl-job/issues/3841)