### PR TITLE
修改cronGen.js，修复cron编辑，运行时间预览问题

### DIFF
--- a/xxl-job-admin/src/main/resources/static/plugins/cronGen/cronGen.js
+++ b/xxl-job-admin/src/main/resources/static/plugins/cronGen/cronGen.js
@@ -1064,11 +1064,11 @@
         cronResult : function() {
             var result;
             var second = $("#secondHidden").val();
-            second = second== "" ? "*":second;
+            second = second== "" ? "0":second;
             var minute = $("#minHidden").val();
-            minute = minute== "" ? "*":minute;
+            minute = minute== "" ? "0":minute;
             var hour = $("#hourHidden").val();
-            hour = hour== "" ? "*":hour;
+            hour = hour== "" ? "0":hour;
             var day = $("#dayHidden").val();
             day = day== "" ? "*":day;
             var month = $("#monthHidden").val();


### PR DESCRIPTION
fix: 当用户直接选择“每小时一次”，此类操作时，下边的运行时间错误的显示为每秒一次；

**What kind of change does this PR introduce?** (check at least one)

- [√] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**


**Other information:**