### PR TITLE
父工程pom文件中spring context依赖被设置成provide，会导致子项目无法运行，疑似配置问题

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,6 @@
 				<groupId>org.springframework</groupId>
 				<artifactId>spring-context</artifactId>
 				<version>${spring.version}</version>
-				<scope>provided</scope>
 			</dependency>
 
 			<!-- mybatis-starter：mybatis + mybatis-spring + hikari（default） -->


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
下载代码后，默认pom配置下无法启动运行admin模块，因为父工程pom文件中将spring context依赖设置成provided，不确定是否有原因这样设置，只是这样代码原本状态无法启动运行。如果有原因这样设置的话，希望能告诉我，让我学习
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**


**Other information:**