### PR TITLE
fix: prevent SSRF via user-controlled addressList in trigger

### DIFF
--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/service/impl/XxlJobServiceImpl.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/service/impl/XxlJobServiceImpl.java
@@ -428,6 +428,25 @@ public class XxlJobServiceImpl implements XxlJobService {
 			return Response.ofFail(I18nUtil.getString("system_permission_limit"));
 		}
 
+		// valid addressList: must be a subset of the group's registered addresses (prevent SSRF)
+		if (StringTool.isNotBlank(addressList)) {
+			XxlJobGroup jobGroup = xxlJobGroupMapper.load(xxlJobInfo.getJobGroup());
+			if (jobGroup == null) {
+				return Response.ofFail(I18nUtil.getString("jobinfo_glue_jobid_unvalid"));
+			}
+			List<String> groupAddressList = jobGroup.getRegistryList();
+			if (groupAddressList == null || groupAddressList.isEmpty()) {
+				return Response.ofFail(I18nUtil.getString("jobgroup_field_registryList_unvalid"));
+			}
+			Set<String> allowedAddresses = new HashSet<>(groupAddressList);
+			String[] inputAddresses = addressList.trim().split(",");
+			for (String addr : inputAddresses) {
+				if (StringTool.isBlank(addr) || !allowedAddresses.contains(addr.trim())) {
+					return Response.ofFail(I18nUtil.getString("jobgroup_field_registryList_unvalid"));
+				}
+			}
+		}
+
 		// force cover job param
 		if (executorParam == null) {
 			executorParam = "";

--- a/xxl-job-admin/src/test/java/com/xxl/job/admin/service/AddressListValidationTest.java
+++ b/xxl-job-admin/src/test/java/com/xxl/job/admin/service/AddressListValidationTest.java
@@ -1,0 +1,94 @@
+package com.xxl.job.admin.service;
+
+import com.xxl.tool.core.StringTool;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for addressList validation logic in trigger flow.
+ * Verifies that user-supplied addressList is validated against the group's registered addresses,
+ * preventing SSRF via arbitrary address injection (Issue #3935).
+ */
+public class AddressListValidationTest {
+
+    /**
+     * Simulates the validation logic from XxlJobServiceImpl.trigger().
+     * Returns true if addressList is valid (all addresses belong to the group), false otherwise.
+     */
+    private boolean isAddressListValid(String addressList, List<String> groupAddressList) {
+        if (!StringTool.isNotBlank(addressList)) {
+            return true; // blank addressList is valid (uses default group addresses)
+        }
+        if (groupAddressList == null || groupAddressList.isEmpty()) {
+            return false;
+        }
+        Set<String> allowedAddresses = new HashSet<>(groupAddressList);
+        String[] inputAddresses = addressList.trim().split(",");
+        for (String addr : inputAddresses) {
+            if (StringTool.isBlank(addr) || !allowedAddresses.contains(addr.trim())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Test
+    public void testValidAddressInGroup() {
+        List<String> groupAddresses = Arrays.asList("http://192.168.1.10:9999", "http://192.168.1.11:9999");
+        assertTrue(isAddressListValid("http://192.168.1.10:9999", groupAddresses));
+    }
+
+    @Test
+    public void testValidMultipleAddressesInGroup() {
+        List<String> groupAddresses = Arrays.asList("http://192.168.1.10:9999", "http://192.168.1.11:9999");
+        assertTrue(isAddressListValid("http://192.168.1.10:9999,http://192.168.1.11:9999", groupAddresses));
+    }
+
+    @Test
+    public void testArbitraryAddressRejected() {
+        List<String> groupAddresses = Arrays.asList("http://192.168.1.10:9999", "http://192.168.1.11:9999");
+        assertFalse(isAddressListValid("http://evil-server.com:8080", groupAddresses));
+    }
+
+    @Test
+    public void testInternalMetadataAddressRejected() {
+        List<String> groupAddresses = Arrays.asList("http://192.168.1.10:9999");
+        assertFalse(isAddressListValid("http://169.254.169.254/latest/meta-data", groupAddresses));
+    }
+
+    @Test
+    public void testMixedValidAndInvalidAddressRejected() {
+        List<String> groupAddresses = Arrays.asList("http://192.168.1.10:9999", "http://192.168.1.11:9999");
+        assertFalse(isAddressListValid("http://192.168.1.10:9999,http://evil-server.com:8080", groupAddresses));
+    }
+
+    @Test
+    public void testBlankAddressListAllowed() {
+        List<String> groupAddresses = Arrays.asList("http://192.168.1.10:9999");
+        assertTrue(isAddressListValid("", groupAddresses));
+        assertTrue(isAddressListValid(null, groupAddresses));
+        assertTrue(isAddressListValid("  ", groupAddresses));
+    }
+
+    @Test
+    public void testEmptyGroupAddressesRejectsAll() {
+        assertFalse(isAddressListValid("http://192.168.1.10:9999", new ArrayList<>()));
+        assertFalse(isAddressListValid("http://192.168.1.10:9999", null));
+    }
+
+    @Test
+    public void testLocalhostAddressRejectedWhenNotInGroup() {
+        List<String> groupAddresses = Arrays.asList("http://192.168.1.10:9999");
+        assertFalse(isAddressListValid("http://127.0.0.1:8080", groupAddresses));
+        assertFalse(isAddressListValid("http://localhost:8080", groupAddresses));
+    }
+
+    @Test
+    public void testDockerInternalAddressRejectedWhenNotInGroup() {
+        List<String> groupAddresses = Arrays.asList("http://192.168.1.10:9999");
+        assertFalse(isAddressListValid("http://canary:8080", groupAddresses));
+    }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

## Problem

The manual trigger endpoint (`/jobinfo/trigger`) accepts a user-controlled `addressList` parameter that is passed directly through the trigger chain to `HttpTool.createClient().url(address)` without any validation. This allows an authenticated user with job group permission to:

- Send server-side HTTP requests to arbitrary URLs (SSRF)
- Leak the `XXL-JOB-ACCESS-TOKEN` header to attacker-controlled servers
- Leak job metadata via the `TriggerRequest` body
- Access internal/Docker-internal services from the admin server's network position

## Root Cause

In `XxlJobServiceImpl.trigger()`, the `addressList` parameter from user input is passed to `JobTriggerPoolHelper.trigger()` without validation. In `JobTrigger.trigger()`, the user-supplied addresses directly override the group's configured addresses:

\`\`\`java
if (StringTool.isNotBlank(addressList)) {
    group.setAddressType(1);
    group.setAddressList(addressList.trim()); // No validation!
}
\`\`\`

Note: `JobGroupController` already validates addresses using `HttpTool.isHttp()/isHttps()` when saving groups, but this validation was missing in the trigger flow.

## Fix

Added validation in `XxlJobServiceImpl.trigger()` that ensures every address in the user-supplied `addressList` is a member of the job group's registered/configured executor addresses. If any address is not in the allowed set, the request is rejected.

This is a whitelist approach — only addresses already registered or configured for the executor group are permitted, which prevents arbitrary URL injection.

## Tests Added

- `AddressListValidationTest` — Unit tests for the address validation logic:
  - `testValidAddressInGroup` — single valid address accepted
  - `testValidMultipleAddressesInGroup` — multiple valid addresses accepted
  - `testArbitraryAddressRejected` — external attacker URL rejected
  - `testInternalMetadataAddressRejected` — cloud metadata endpoint rejected
  - `testMixedValidAndInvalidAddressRejected` — partial match rejected
  - `testBlankAddressListAllowed` — blank/null input uses defaults
  - `testEmptyGroupAddressesRejectsAll` — empty group rejects all
  - `testLocalhostAddressRejectedWhenNotInGroup` — localhost SSRF prevented
  - `testDockerInternalAddressRejectedWhenNotInGroup` — Docker-internal SSRF prevented

**Note:** Local JDK is 1.8 while the project requires 17+, so tests could not be run locally. Test logic has been verified by code review. CI will run the full test suite.

## Impact

- Scope: Only affects the manual trigger endpoint (/jobinfo/trigger)
- No behavioral change for legitimate use — users can still specify addresses that belong to the executor group
- Minimal change: 19 lines of validation code added

Fixes #3935