### PR TITLE
feat: add schedule time zone support for cron jobs

### DIFF
--- a/doc/db/tables_xxl_job.sql
+++ b/doc/db/tables_xxl_job.sql
@@ -61,6 +61,7 @@ CREATE TABLE `xxl_job_info`
     `trigger_status`            tinyint(4)   NOT NULL DEFAULT '0' COMMENT '调度状态：0-停止，1-运行',
     `trigger_last_time`         bigint(13)   NOT NULL DEFAULT '0' COMMENT '上次调度时间',
     `trigger_next_time`         bigint(13)   NOT NULL DEFAULT '0' COMMENT '下次调度时间',
+    `schedule_time_zone`        varchar(50)           DEFAULT NULL COMMENT '调度时区，如 Asia/Shanghai',
     PRIMARY KEY (`id`)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4;

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/controller/biz/JobInfoController.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/controller/biz/JobInfoController.java
@@ -171,7 +171,8 @@ public class JobInfoController {
 	@RequestMapping("/nextTriggerTime")
 	@ResponseBody
 	public Response<List<String>> nextTriggerTime(@RequestParam("scheduleType") String scheduleType,
-												 @RequestParam("scheduleConf") String scheduleConf) {
+												 @RequestParam("scheduleConf") String scheduleConf,
+												 @RequestParam(value = "scheduleTimeZone", required = false) String scheduleTimeZone) {
 
 		// valid
 		if (StringTool.isBlank(scheduleType) || StringTool.isBlank(scheduleConf)) {
@@ -182,6 +183,7 @@ public class JobInfoController {
 		XxlJobInfo paramXxlJobInfo = new XxlJobInfo();
 		paramXxlJobInfo.setScheduleType(scheduleType);
 		paramXxlJobInfo.setScheduleConf(scheduleConf);
+		paramXxlJobInfo.setScheduleTimeZone(scheduleTimeZone);
 
 		// generate
 		List<String> result = new ArrayList<>();

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/model/XxlJobInfo.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/model/XxlJobInfo.java
@@ -42,6 +42,8 @@ public class XxlJobInfo {
 	private long triggerLastTime;	// 上次调度时间
 	private long triggerNextTime;	// 下次调度时间
 
+	private String scheduleTimeZone;	// 调度时区，如 Asia/Shanghai、Europe/Moscow
+
 
 	public int getId() {
 		return id;
@@ -233,5 +235,13 @@ public class XxlJobInfo {
 
 	public void setTriggerNextTime(long triggerNextTime) {
 		this.triggerNextTime = triggerNextTime;
+	}
+
+	public String getScheduleTimeZone() {
+		return scheduleTimeZone;
+	}
+
+	public void setScheduleTimeZone(String scheduleTimeZone) {
+		this.scheduleTimeZone = scheduleTimeZone;
 	}
 }

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/scheduler/type/strategy/CronScheduleType.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/scheduler/type/strategy/CronScheduleType.java
@@ -5,13 +5,17 @@ import com.xxl.job.admin.scheduler.cron.CronExpression;
 import com.xxl.job.admin.scheduler.type.ScheduleType;
 
 import java.util.Date;
+import java.util.TimeZone;
 
 public class CronScheduleType extends ScheduleType {
 
     @Override
     public Date generateNextTriggerTime(XxlJobInfo jobInfo, Date fromTime) throws Exception {
-        // generate next trigger time, with cron
-        return new CronExpression(jobInfo.getScheduleConf()).getNextValidTimeAfter(fromTime);
+        CronExpression cronExpression = new CronExpression(jobInfo.getScheduleConf());
+        if (jobInfo.getScheduleTimeZone() != null && !jobInfo.getScheduleTimeZone().isEmpty()) {
+            cronExpression.setTimeZone(TimeZone.getTimeZone(jobInfo.getScheduleTimeZone()));
+        }
+        return cronExpression.getNextValidTimeAfter(fromTime);
     }
 
 }

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/service/impl/XxlJobServiceImpl.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/service/impl/XxlJobServiceImpl.java
@@ -158,6 +158,9 @@ public class XxlJobServiceImpl implements XxlJobService {
 		}
 
 		// add in db
+		if (jobInfo.getScheduleTimeZone() == null || jobInfo.getScheduleTimeZone().isEmpty()) {
+			jobInfo.setScheduleTimeZone(TimeZone.getDefault().getID());
+		}
 		jobInfo.setAddTime(new Date());
 		jobInfo.setUpdateTime(new Date());
 		jobInfo.setGlueUpdatetime(new Date());
@@ -273,7 +276,8 @@ public class XxlJobServiceImpl implements XxlJobService {
 		// next trigger time (5s后生效，避开预读周期)
 		long nextTriggerTime = exists_jobInfo.getTriggerNextTime();
 		boolean scheduleDataNotChanged = jobInfo.getScheduleType().equals(exists_jobInfo.getScheduleType())
-				&& jobInfo.getScheduleConf().equals(exists_jobInfo.getScheduleConf());		// 触发配置如果不变，避免重复计算；
+				&& jobInfo.getScheduleConf().equals(exists_jobInfo.getScheduleConf())
+				&& (jobInfo.getScheduleTimeZone() != null ? jobInfo.getScheduleTimeZone().equals(exists_jobInfo.getScheduleTimeZone()) : exists_jobInfo.getScheduleTimeZone() == null);
 		if (exists_jobInfo.getTriggerStatus() == TriggerStatus.RUNNING.getValue() && !scheduleDataNotChanged) {
 			try {
 				// generate next trigger time
@@ -303,6 +307,7 @@ public class XxlJobServiceImpl implements XxlJobService {
 		exists_jobInfo.setExecutorTimeout(jobInfo.getExecutorTimeout());
 		exists_jobInfo.setExecutorFailRetryCount(jobInfo.getExecutorFailRetryCount());
 		exists_jobInfo.setChildJobId(jobInfo.getChildJobId());
+		exists_jobInfo.setScheduleTimeZone(jobInfo.getScheduleTimeZone());
 		exists_jobInfo.setTriggerNextTime(nextTriggerTime);
 
 		exists_jobInfo.setUpdateTime(new Date());

--- a/xxl-job-admin/src/main/resources/mapper/XxlJobInfoMapper.xml
+++ b/xxl-job-admin/src/main/resources/mapper/XxlJobInfoMapper.xml
@@ -36,6 +36,7 @@
 		<result column="trigger_status" property="triggerStatus" />
 		<result column="trigger_last_time" property="triggerLastTime" />
 		<result column="trigger_next_time" property="triggerNextTime" />
+		<result column="schedule_time_zone" property="scheduleTimeZone" />
 	</resultMap>
 
 	<sql id="Base_Column_List">
@@ -62,7 +63,8 @@
 		t.child_jobid,
 		t.trigger_status,
 		t.trigger_last_time,
-		t.trigger_next_time
+		t.trigger_next_time,
+		t.schedule_time_zone
 	</sql>
 
 	<select id="pageList" parameterType="java.util.HashMap" resultMap="XxlJobInfo">
@@ -135,7 +137,8 @@
 			child_jobid,
 			trigger_status,
 			trigger_last_time,
-			trigger_next_time
+			trigger_next_time,
+			schedule_time_zone
 		) VALUES (
 			#{jobGroup},
 			#{jobDesc},
@@ -159,7 +162,8 @@
 			#{childJobId},
 			#{triggerStatus},
 			#{triggerLastTime},
-			#{triggerNextTime}
+			#{triggerNextTime},
+			#{scheduleTimeZone}
 		);
 		<!--<selectKey resultType="java.lang.Integer" order="AFTER" keyProperty="id">
 			SELECT LAST_INSERT_ID()
@@ -197,7 +201,8 @@
 			child_jobid = #{childJobId},
 			trigger_status = #{triggerStatus},
 			trigger_last_time = #{triggerLastTime},
-			trigger_next_time = #{triggerNextTime}
+			trigger_next_time = #{triggerNextTime},
+			schedule_time_zone = #{scheduleTimeZone}
 		WHERE id = #{id}
 	</update>
 

--- a/xxl-job-admin/src/test/java/com/xxl/job/admin/model/XxlJobInfoTest.java
+++ b/xxl-job-admin/src/test/java/com/xxl/job/admin/model/XxlJobInfoTest.java
@@ -1,0 +1,27 @@
+package com.xxl.job.admin.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class XxlJobInfoTest {
+
+    @Test
+    public void testScheduleTimeZoneGetterSetter() {
+        XxlJobInfo info = new XxlJobInfo();
+
+        assertNull(info.getScheduleTimeZone());
+
+        info.setScheduleTimeZone("Asia/Shanghai");
+        assertEquals("Asia/Shanghai", info.getScheduleTimeZone());
+
+        info.setScheduleTimeZone("Europe/Moscow");
+        assertEquals("Europe/Moscow", info.getScheduleTimeZone());
+
+        info.setScheduleTimeZone(null);
+        assertNull(info.getScheduleTimeZone());
+
+        info.setScheduleTimeZone("");
+        assertEquals("", info.getScheduleTimeZone());
+    }
+}

--- a/xxl-job-admin/src/test/java/com/xxl/job/admin/schedule/CronScheduleTypeTest.java
+++ b/xxl-job-admin/src/test/java/com/xxl/job/admin/schedule/CronScheduleTypeTest.java
@@ -1,0 +1,132 @@
+package com.xxl.job.admin.schedule;
+
+import com.xxl.job.admin.model.XxlJobInfo;
+import com.xxl.job.admin.scheduler.type.strategy.CronScheduleType;
+import org.junit.jupiter.api.Test;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CronScheduleTypeTest {
+
+    private final CronScheduleType cronScheduleType = new CronScheduleType();
+
+    @Test
+    public void testGenerateNextTriggerTime_noTimeZone() throws Exception {
+        XxlJobInfo jobInfo = new XxlJobInfo();
+        jobInfo.setScheduleConf("0 0 8 * * ?");
+        jobInfo.setScheduleTimeZone(null);
+
+        Date fromTime = new Date();
+        Date result = cronScheduleType.generateNextTriggerTime(jobInfo, fromTime);
+
+        assertNotNull(result);
+        assertTrue(result.after(fromTime));
+    }
+
+    @Test
+    public void testGenerateNextTriggerTime_emptyTimeZone() throws Exception {
+        XxlJobInfo jobInfo = new XxlJobInfo();
+        jobInfo.setScheduleConf("0 0 8 * * ?");
+        jobInfo.setScheduleTimeZone("");
+
+        Date fromTime = new Date();
+        Date result = cronScheduleType.generateNextTriggerTime(jobInfo, fromTime);
+
+        assertNotNull(result);
+        assertTrue(result.after(fromTime));
+    }
+
+    @Test
+    public void testGenerateNextTriggerTime_withTimeZone_shanghai() throws Exception {
+        XxlJobInfo jobInfo = new XxlJobInfo();
+        jobInfo.setScheduleConf("0 0 8 * * ?");
+        jobInfo.setScheduleTimeZone("Asia/Shanghai");
+
+        Date fromTime = new Date();
+        Date result = cronScheduleType.generateNextTriggerTime(jobInfo, fromTime);
+
+        assertNotNull(result);
+        assertTrue(result.after(fromTime));
+
+        SimpleDateFormat sdf = new SimpleDateFormat("HH:mm:ss");
+        sdf.setTimeZone(TimeZone.getTimeZone("Asia/Shanghai"));
+        String timeStr = sdf.format(result);
+        assertTrue(timeStr.startsWith("08:00:00"), "Expected 08:00:00 in Asia/Shanghai, got " + timeStr);
+    }
+
+    @Test
+    public void testGenerateNextTriggerTime_withTimeZone_moscow() throws Exception {
+        XxlJobInfo jobInfo = new XxlJobInfo();
+        jobInfo.setScheduleConf("0 0 8 * * ?");
+        jobInfo.setScheduleTimeZone("Europe/Moscow");
+
+        Date fromTime = new Date();
+        Date result = cronScheduleType.generateNextTriggerTime(jobInfo, fromTime);
+
+        assertNotNull(result);
+        assertTrue(result.after(fromTime));
+
+        SimpleDateFormat sdf = new SimpleDateFormat("HH:mm:ss");
+        sdf.setTimeZone(TimeZone.getTimeZone("Europe/Moscow"));
+        String timeStr = sdf.format(result);
+        assertTrue(timeStr.startsWith("08:00:00"), "Expected 08:00:00 in Europe/Moscow, got " + timeStr);
+    }
+
+    @Test
+    public void testDifferentTimeZones_produceDifferentResults() throws Exception {
+        XxlJobInfo jobInfoShanghai = new XxlJobInfo();
+        jobInfoShanghai.setScheduleConf("0 0 8 * * ?");
+        jobInfoShanghai.setScheduleTimeZone("Asia/Shanghai");
+
+        XxlJobInfo jobInfoMoscow = new XxlJobInfo();
+        jobInfoMoscow.setScheduleConf("0 0 8 * * ?");
+        jobInfoMoscow.setScheduleTimeZone("Europe/Moscow");
+
+        Date fromTime = new Date();
+        Date resultShanghai = cronScheduleType.generateNextTriggerTime(jobInfoShanghai, fromTime);
+        Date resultMoscow = cronScheduleType.generateNextTriggerTime(jobInfoMoscow, fromTime);
+
+        assertNotNull(resultShanghai);
+        assertNotNull(resultMoscow);
+
+        assertNotEquals(resultShanghai.getTime(), resultMoscow.getTime(),
+                "Same cron expression with different time zones should produce different absolute trigger times");
+    }
+
+    @Test
+    public void testUtcTimeZone() throws Exception {
+        XxlJobInfo jobInfo = new XxlJobInfo();
+        jobInfo.setScheduleConf("0 30 14 * * ?");
+        jobInfo.setScheduleTimeZone("UTC");
+
+        Date fromTime = new Date();
+        Date result = cronScheduleType.generateNextTriggerTime(jobInfo, fromTime);
+
+        assertNotNull(result);
+        assertTrue(result.after(fromTime));
+
+        SimpleDateFormat sdf = new SimpleDateFormat("HH:mm:ss");
+        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+        String timeStr = sdf.format(result);
+        assertTrue(timeStr.startsWith("14:30:00"), "Expected 14:30:00 in UTC, got " + timeStr);
+    }
+
+    @Test
+    public void testMultipleTriggers_sameTimeZone() throws Exception {
+        XxlJobInfo jobInfo = new XxlJobInfo();
+        jobInfo.setScheduleConf("0 0/30 * * * ?");
+        jobInfo.setScheduleTimeZone("Asia/Tokyo");
+
+        Date lastTime = new Date();
+        for (int i = 0; i < 5; i++) {
+            Date nextTime = cronScheduleType.generateNextTriggerTime(jobInfo, lastTime);
+            assertNotNull(nextTime);
+            assertTrue(nextTime.after(lastTime));
+            lastTime = nextTime;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add `schedule_time_zone` field to allow specifying the time zone for cron job scheduling. This enables users to schedule jobs in different time zones (e.g., `Asia/Shanghai`, `Europe/Moscow`) without relying on the server's default time zone.

## Changes

- **Model**: Add `scheduleTimeZone` field to `XxlJobInfo`
- **Scheduler**: Apply time zone to `CronExpression` in `CronScheduleType` via `setTimeZone()`
- **Mapper**: Update MyBatis mapper (resultMap, Base_Column_List, INSERT, UPDATE) for the new DB column
- **Controller**: Add `scheduleTimeZone` parameter to `nextTriggerTime` API
- **Service**: Set default time zone on job creation; detect schedule config changes including time zone
- **SQL**: Add `schedule_time_zone` column to `tables_xxl_job.sql`

## DB Migration

``sql
ALTER TABLE xxl_job_info ADD COLUMN `schedule_time_zone` varchar(50) DEFAULT NULL COMMENT 'schedule timezone, e.g. Asia/Shanghai' AFTER `trigger_next_time`;
``

## Tests

- `CronScheduleTypeTest`: 7 test cases covering null/empty/valid time zones, cross-timezone differences, UTC, and multiple triggers
- `XxlJobInfoTest`: 1 test case for model field getter/setter
- All 8 tests passed

## Usage Example

A cron job with `0 0 8 * * ?` and `schedule_time_zone=Asia/Shanghai` will fire at 8:00 AM Shanghai time, regardless of the server's system time zone.