### PR TITLE
fix(core): refresh callbackLogPath in initLogPath (#3959)

### DIFF
--- a/xxl-job-core/pom.xml
+++ b/xxl-job-core/pom.xml
@@ -59,6 +59,13 @@
 			<scope>provided</scope>
 		</dependency>
 
+		<!-- ********************** test ********************** -->
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 </project>

--- a/xxl-job-core/src/main/java/com/xxl/job/core/log/XxlJobFileAppender.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/log/XxlJobFileAppender.java
@@ -50,6 +50,11 @@ public class XxlJobFileAppender {
 		File glueBaseDir = new File(logPathDir, "gluesource");
         FileTool.createDirectories(glueBaseDir);
 		glueSrcPath = glueBaseDir.getPath();
+
+		// mk callback log dir
+		File callbackBaseDir = new File(logPathDir, "callbacklogs");
+        FileTool.createDirectories(callbackBaseDir);
+		callbackLogPath = callbackBaseDir.getPath();
 	}
 	public static String getLogPath() {
 		return logBasePath;

--- a/xxl-job-core/src/test/java/com/xxl/job/core/log/XxlJobFileAppenderTest.java
+++ b/xxl-job-core/src/test/java/com/xxl/job/core/log/XxlJobFileAppenderTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 1999-2026 xuxueli.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.xxl.job.core.log;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression test for issue #3959:
+ * initLogPath should refresh callbackLogPath together with logBasePath and glueSrcPath.
+ */
+class XxlJobFileAppenderTest {
+
+    @Test
+    void initLogPath_shouldRefreshCallbackLogPathRelativeToCustomLogBase(@TempDir Path tempDir) throws IOException {
+        String customLogPath = tempDir.toFile().getPath();
+
+        XxlJobFileAppender.initLogPath(customLogPath);
+
+        File expectedCallbackDir = new File(customLogPath, "callbacklogs");
+        assertEquals(expectedCallbackDir.getPath(), XxlJobFileAppender.getCallbackLogPath(),
+                "callbackLogPath should sit under the user-supplied logPath after initLogPath");
+    }
+
+    @Test
+    void initLogPath_shouldRefreshGlueSrcPathRelativeToCustomLogBase(@TempDir Path tempDir) throws IOException {
+        String customLogPath = tempDir.toFile().getPath();
+
+        XxlJobFileAppender.initLogPath(customLogPath);
+
+        File expectedGlueDir = new File(customLogPath, "gluesource");
+        assertEquals(expectedGlueDir.getPath(), XxlJobFileAppender.getGlueSrcPath());
+        assertTrue(expectedGlueDir.exists(), "gluesource directory should be created under custom logPath");
+    }
+}


### PR DESCRIPTION
[x] Bugfix

## Description

`XxlJobFileAppender.initLogPath` refreshes `logBasePath` and `glueSrcPath` when a custom log path is supplied, but `callbackLogPath` keeps its class-load-time default `/data/applogs/xxl-job/jobhandler/callbacklogs`. As a result:

- `TriggerCallbackThread` writes offline callback retry logs to the hard-coded default path instead of the user-configured one.
- On restart, the offline-callback directory scan also looks at the wrong path, so queued callbacks from the previous run are never replayed.

## Fix

Refresh `callbackLogPath` together with `glueSrcPath` inside `initLogPath` so all three paths stay in sync.

## Test

Added `XxlJobFileAppenderTest` under `xxl-job-core` with two cases using `@TempDir`:
- `callbackLogPath` sits under the user-supplied log path (fails on master, passes with fix).
- `glueSrcPath` sits under the user-supplied log path and the directory is created (sanity, passes both).

closes #3959

---
Assisted-by: Claude Code