### PR TITLE
feat: 执行器日志文件合并优化，每Job每天一个文件

### DIFF
--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/business/controller/JobLogController.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/business/controller/JobLogController.java
@@ -305,7 +305,7 @@ public class JobLogController {
 
 			// log cat
 			ExecutorBiz executorBiz = XxlJobAdminBootstrap.getExecutorBiz(jobLog.getExecutorAddress(), jobGroup);
-			Response<LogData> logResult = executorBiz.log(new LogRequest(logId, jobLog.getTriggerTime().getTime(), fromLineNum));
+			Response<LogData> logResult = executorBiz.log(new LogRequest(logId, jobLog.getTriggerTime().getTime(), jobLog.getJobId(), fromLineNum));
 
 			// is end
 			if (logResult.getData()!=null && logResult.getData().getFromLineNum() > logResult.getData().getToLineNum()) {

--- a/xxl-job-core/src/main/java/com/xxl/job/core/executor/XxlJobExecutor.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/executor/XxlJobExecutor.java
@@ -56,6 +56,7 @@ public class XxlJobExecutor  {
     private String address;                                         // executor registry-address: default use address to registry , otherwise use ip:port if address is null
     private String logPath = "/data/applogs/xxl-job/jobhandler";    // executor log-path
     private int logRetentionDays = 30;                              // executor log-retention-days
+    private boolean logIsolatedByAddress = false;                   // executor log isolated by address (for shared PVC), default false
     private boolean glueEnabled = true;                             // executor glue (non-BEAN) task enable, default true
 
     public void setAdminAddresses(String adminAddresses) {
@@ -87,6 +88,9 @@ public class XxlJobExecutor  {
     }
     public void setLogRetentionDays(int logRetentionDays) {
         this.logRetentionDays = logRetentionDays;
+    }
+    public void setLogIsolatedByAddress(boolean logIsolatedByAddress) {
+        this.logIsolatedByAddress = logIsolatedByAddress;
     }
     public void setGlueEnabled(boolean glueEnabled) {
         this.glueEnabled = glueEnabled;
@@ -164,6 +168,11 @@ public class XxlJobExecutor  {
         // 3、EmbedServer + ExecutorRegistryThreadHelper
         executorRegistryThreadHelper = new ExecutorRegistryThreadHelper();
         startEmbedServer();
+
+        // 4、init log isolation (after address resolved)
+        if (logIsolatedByAddress) {
+            XxlJobFileAppender.setLogIsolation(true, this.address);
+        }
     }
 
     /**

--- a/xxl-job-core/src/main/java/com/xxl/job/core/log/XxlJobFileAppender.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/log/XxlJobFileAppender.java
@@ -7,8 +7,8 @@ import com.xxl.tool.io.FileTool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.IOException;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -22,6 +22,13 @@ import java.util.function.Consumer;
 public class XxlJobFileAppender {
 	private static final Logger logger = LoggerFactory.getLogger(XxlJobFileAppender.class);
 
+	// ---------------------- log segment markers ----------------------
+
+	public static final String LOG_SEGMENT_START_PREFIX = "=====[LOG_ID:";
+	public static final String LOG_SEGMENT_START_SUFFIX = "][START]=====";
+	public static final String LOG_SEGMENT_END_PREFIX = "=====[LOG_ID:";
+	public static final String LOG_SEGMENT_END_SUFFIX = "][END]=====";
+
 	/**
 	 * log base path
 	 *
@@ -29,13 +36,15 @@ public class XxlJobFileAppender {
 	 * 	---/
 	 * 	---/gluesource/10_1514171108000.js
 	 * 	---/callbacklogs/xxl-job-callback-1761412677119.log
-	 * 	---/2017-12-25/639.log
-	 * 	---/2017-12-25/821.log
+	 * 	---/2017-12-25/job-7.log
+	 * 	---/2017-12-25/job-7.idx
 	 *
 	 */
 	private static String logBasePath;
 	private static String glueSrcPath;
 	private static String callbackLogPath;
+	private static boolean logIsolatedByAddress = false;
+	private static String executorAddress;
 
 	/**
 	 * init log path
@@ -73,20 +82,67 @@ public class XxlJobFileAppender {
 	}
 
 	/**
-	 * log filename, like "logPath/yyyy-MM-dd/9999.log"
-	 *
-	 * @param logId log id
-	 * @return      log file name
+	 * set log isolation config
 	 */
-	public static String makeLogFileName(Date triggerDate, long logId) {
+	public static void setLogIsolation(boolean isolated, String address) {
+		logIsolatedByAddress = isolated;
+		executorAddress = address;
+	}
 
+	// ---------------------- log file name ----------------------
+
+	/**
+	 * log filename (new format), like "logPath/yyyy-MM-dd/job-7.log"
+	 * or with isolation: "logPath/yyyy-MM-dd/{address}/job-7.log"
+	 *
+	 * @param triggerDate trigger date
+	 * @param jobId       job id
+	 * @return log file name
+	 */
+	public static String makeLogFileName(Date triggerDate, int jobId) {
+		// "filePath/yyyy-MM-dd" or "filePath/yyyy-MM-dd/{address}"
+		File logFilePath = new File(getLogPath(), DateTool.formatDate(triggerDate));
+		if (logIsolatedByAddress && executorAddress != null && !executorAddress.isEmpty()) {
+			// extract ip_port from address (strip protocol and trailing slash)
+			String addressDir = executorAddress;
+			if (addressDir.contains("://")) {
+				addressDir = addressDir.substring(addressDir.indexOf("://") + 3);
+			}
+			if (addressDir.endsWith("/")) {
+				addressDir = addressDir.substring(0, addressDir.length() - 1);
+			}
+			addressDir = addressDir.replace(':', '_');
+			logFilePath = new File(logFilePath, addressDir);
+		}
+		try {
+			FileTool.createDirectories(logFilePath);
+		} catch (IOException e) {
+			throw new RuntimeException("XxlJobFileAppender makeLogFileName error, logFilePath:" + logFilePath.getPath(), e);
+		}
+
+		// filePath/yyyy-MM-dd/job-7.log
+		return logFilePath.getPath()
+				.concat(File.separator)
+				.concat("job-")
+				.concat(String.valueOf(jobId))
+				.concat(".log");
+	}
+
+	/**
+	 * log filename (legacy format), like "logPath/yyyy-MM-dd/9999.log"
+	 *
+	 * @param triggerDate trigger date
+	 * @param logId       log id
+	 * @return log file name
+	 */
+	public static String makeLogFileNameLegacy(Date triggerDate, long logId) {
 		// "filePath/yyyy-MM-dd"
 		File logFilePath = new File(getLogPath(), DateTool.formatDate(triggerDate));
-        try {
-            FileTool.createDirectories(logFilePath);
-        } catch (IOException e) {
-            throw new RuntimeException("XxlJobFileAppender makeLogFileName error, logFilePath:"+ logFilePath.getPath(), e);
-        }
+		try {
+			FileTool.createDirectories(logFilePath);
+		} catch (IOException e) {
+			throw new RuntimeException("XxlJobFileAppender makeLogFileNameLegacy error, logFilePath:" + logFilePath.getPath(), e);
+		}
 
         // filePath/yyyy-MM-dd/9999.log
         return logFilePath.getPath()
@@ -117,7 +173,207 @@ public class XxlJobFileAppender {
 	}
 
 	/**
-	 * support read log-file
+	 * append START marker and write index entry
+	 *
+	 * @param logFileName log file name
+	 * @param logId       log id
+	 */
+	public static void appendLogStart(String logFileName, long logId) {
+		// 1. get current file size as byte offset for index
+		File logFile = new File(logFileName);
+		long offset = logFile.exists() ? logFile.length() : 0;
+
+		// 2. write START marker to log file
+		appendLog(logFileName, LOG_SEGMENT_START_PREFIX + logId + LOG_SEGMENT_START_SUFFIX);
+
+		// 3. append index record to .idx file
+		String idxFileName = logFileName.replace(".log", ".idx");
+		try {
+			FileTool.writeLines(idxFileName, List.of(logId + "," + offset), true);
+		} catch (IOException e) {
+			logger.error("XxlJobFileAppender appendLogStart write index error, idxFileName:{}", idxFileName, e);
+		}
+	}
+
+	/**
+	 * append END marker
+	 *
+	 * @param logFileName log file name
+	 * @param logId       log id
+	 */
+	public static void appendLogEnd(String logFileName, long logId) {
+		appendLog(logFileName, LOG_SEGMENT_END_PREFIX + logId + LOG_SEGMENT_END_SUFFIX);
+	}
+
+	// ---------------------- read log ----------------------
+
+	/**
+	 * read log by logId from merged log file, using index for fast seek
+	 *
+	 * @param logFileName log file name
+	 * @param logId       log id to locate segment
+	 * @param fromLineNum from line num (within the segment, start as 1)
+	 * @return log data
+	 */
+	public static LogData readLogByLogId(String logFileName, long logId, int fromLineNum) {
+		// valid
+		if (StringTool.isBlank(logFileName)) {
+			return new LogData(fromLineNum, 0, "readLog fail, logFile not found", true);
+		}
+		if (!FileTool.exists(logFileName)) {
+			return new LogData(fromLineNum, 0, "readLog fail, logFile not exists", true);
+		}
+
+		// 1. lookup offset from index
+		String idxFileName = logFileName.replace(".log", ".idx");
+		long byteOffset = lookupOffset(idxFileName, logId);
+
+		// 2. read log segment
+		String startMarker = LOG_SEGMENT_START_PREFIX + logId + LOG_SEGMENT_START_SUFFIX;
+		String endMarker = LOG_SEGMENT_END_PREFIX + logId + LOG_SEGMENT_END_SUFFIX;
+
+		StringBuilder logContentBuilder = new StringBuilder();
+		int segmentLineNum = 0;
+		int toLineNum = 0;
+		boolean foundStart = false;
+		boolean isEnd = false;
+
+		try (RandomAccessFile raf = new RandomAccessFile(logFileName, "r");
+			 BufferedReader reader = new BufferedReader(
+					 new InputStreamReader(new FileInputStream(raf.getFD()), StandardCharsets.UTF_8))) {
+
+			// seek to offset if available
+			if (byteOffset > 0) {
+				raf.seek(byteOffset);
+			}
+
+			String line;
+			while ((line = reader.readLine()) != null) {
+				// look for START marker
+				if (!foundStart) {
+					if (line.equals(startMarker)) {
+						foundStart = true;
+					}
+					continue;
+				}
+
+				// check END conditions
+				if (line.equals(endMarker)) {
+					// condition a) normal end - mark as end but continue reading until next START
+					isEnd = true;
+					continue;
+				}
+				if (line.startsWith(LOG_SEGMENT_START_PREFIX) && line.endsWith(LOG_SEGMENT_START_SUFFIX)) {
+					// condition b) next segment started
+					break;
+				}
+
+				// collect content lines
+				segmentLineNum++;
+				if (segmentLineNum >= fromLineNum) {
+					toLineNum = segmentLineNum;
+					logContentBuilder.append(line).append(System.lineSeparator());
+				}
+			}
+
+			// if START marker not found at offset position, fallback to full scan
+			if (!foundStart && byteOffset > 0) {
+				return readLogByLogIdFullScan(logFileName, logId, fromLineNum);
+			}
+
+		} catch (IOException e) {
+			logger.error("XxlJobFileAppender readLogByLogId error, logFileName:{}, logId:{}", logFileName, logId, e);
+		}
+
+		// if START not found at all
+		if (!foundStart) {
+			return new LogData(fromLineNum, 0, "readLog fail, logId segment not found", true);
+		}
+
+		return new LogData(fromLineNum, toLineNum, logContentBuilder.toString(), isEnd);
+	}
+
+	/**
+	 * fallback: read log by logId with full file scan (when index is unavailable or invalid)
+	 */
+	private static LogData readLogByLogIdFullScan(String logFileName, long logId, int fromLineNum) {
+		String startMarker = LOG_SEGMENT_START_PREFIX + logId + LOG_SEGMENT_START_SUFFIX;
+		String endMarker = LOG_SEGMENT_END_PREFIX + logId + LOG_SEGMENT_END_SUFFIX;
+
+		StringBuilder logContentBuilder = new StringBuilder();
+		int segmentLineNum = 0;
+		int toLineNum = 0;
+		boolean foundStart = false;
+		boolean isEnd = false;
+
+		try (BufferedReader reader = new BufferedReader(
+				new InputStreamReader(new FileInputStream(logFileName), StandardCharsets.UTF_8))) {
+
+			String line;
+			while ((line = reader.readLine()) != null) {
+				if (!foundStart) {
+					if (line.equals(startMarker)) {
+						foundStart = true;
+					}
+					continue;
+				}
+
+				if (line.equals(endMarker)) {
+					isEnd = true;
+					continue;
+				}
+				if (line.startsWith(LOG_SEGMENT_START_PREFIX) && line.endsWith(LOG_SEGMENT_START_SUFFIX)) {
+					break;
+				}
+
+				segmentLineNum++;
+				if (segmentLineNum >= fromLineNum) {
+					toLineNum = segmentLineNum;
+					logContentBuilder.append(line).append(System.lineSeparator());
+				}
+			}
+		} catch (IOException e) {
+			logger.error("XxlJobFileAppender readLogByLogIdFullScan error, logFileName:{}, logId:{}", logFileName, logId, e);
+		}
+
+		if (!foundStart) {
+			return new LogData(fromLineNum, 0, "readLog fail, logId segment not found", true);
+		}
+
+		return new LogData(fromLineNum, toLineNum, logContentBuilder.toString(), isEnd);
+	}
+
+	/**
+	 * lookup byte offset from index file
+	 *
+	 * @param idxFileName index file name
+	 * @param logId       log id to lookup
+	 * @return byte offset, or -1 if not found
+	 */
+	private static long lookupOffset(String idxFileName, long logId) {
+		if (!FileTool.exists(idxFileName)) {
+			return -1;
+		}
+
+		String targetPrefix = logId + ",";
+		try (BufferedReader reader = new BufferedReader(
+				new InputStreamReader(new FileInputStream(idxFileName), StandardCharsets.UTF_8))) {
+			String line;
+			while ((line = reader.readLine()) != null) {
+				if (line.startsWith(targetPrefix)) {
+					return Long.parseLong(line.substring(targetPrefix.length()));
+				}
+			}
+		} catch (IOException | NumberFormatException e) {
+			logger.error("XxlJobFileAppender lookupOffset error, idxFileName:{}, logId:{}", idxFileName, logId, e);
+		}
+		return -1;
+	}
+
+	// ---------------------- legacy read log (for backward compatibility) ----------------------
+
+	/**
+	 * support read log-file (legacy: one file per execution)
 	 *
 	 * @param logFileName	log file name
 	 * @param fromLineNum	from line num

--- a/xxl-job-core/src/main/java/com/xxl/job/core/openapi/admin/dto/CallbackData.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/openapi/admin/dto/CallbackData.java
@@ -10,14 +10,16 @@ public class CallbackData implements Serializable {
 
     private long logId;
     private long logDateTime;
+    private int jobId;
 
     private int handleCode;
     private String handleMsg;
 
     public CallbackData(){}
-    public CallbackData(long logId, long logDateTime, int handleCode, String handleMsg) {
+    public CallbackData(long logId, long logDateTime, int jobId, int handleCode, String handleMsg) {
         this.logId = logId;
         this.logDateTime = logDateTime;
+        this.jobId = jobId;
         this.handleCode = handleCode;
         this.handleMsg = handleMsg;
     }
@@ -36,6 +38,14 @@ public class CallbackData implements Serializable {
 
     public void setLogDateTime(long logDateTime) {
         this.logDateTime = logDateTime;
+    }
+
+    public int getJobId() {
+        return jobId;
+    }
+
+    public void setJobId(int jobId) {
+        this.jobId = jobId;
     }
 
     public int getHandleCode() {
@@ -59,6 +69,7 @@ public class CallbackData implements Serializable {
         return "CallbackRequest{" +
                 "logId=" + logId +
                 ", logDateTime=" + logDateTime +
+                ", jobId=" + jobId +
                 ", handleCode=" + handleCode +
                 ", handleMsg='" + handleMsg + '\'' +
                 '}';

--- a/xxl-job-core/src/main/java/com/xxl/job/core/openapi/executor/dto/LogRequest.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/openapi/executor/dto/LogRequest.java
@@ -10,13 +10,15 @@ public class LogRequest implements Serializable {
 
     private long logId;
     private long logDateTime;
+    private int jobId;
     private int fromLineNum;
 
     public LogRequest() {
     }
-    public LogRequest(long logId, long logDateTime, int fromLineNum) {
+    public LogRequest(long logId, long logDateTime, int jobId, int fromLineNum) {
         this.logId = logId;
         this.logDateTime = logDateTime;
+        this.jobId = jobId;
         this.fromLineNum = fromLineNum;
     }
 
@@ -34,6 +36,14 @@ public class LogRequest implements Serializable {
 
     public void setLogId(long logId) {
         this.logId = logId;
+    }
+
+    public int getJobId() {
+        return jobId;
+    }
+
+    public void setJobId(int jobId) {
+        this.jobId = jobId;
     }
 
     public int getFromLineNum() {

--- a/xxl-job-core/src/main/java/com/xxl/job/core/openapi/executor/impl/ExecutorBizImpl.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/openapi/executor/impl/ExecutorBizImpl.java
@@ -173,10 +173,21 @@ public class ExecutorBizImpl implements ExecutorBiz {
 
     @Override
     public Response<LogData> log(LogRequest logRequest) {
-        // log filename: logPath/yyyy-MM-dd/9999.log
-        String logFileName = XxlJobFileAppender.makeLogFileName(new Date(logRequest.getLogDateTime()), logRequest.getLogId());
+        // try new format first: logPath/yyyy-MM-dd/job-{jobId}.log
+        if (logRequest.getJobId() > 0) {
+            String newLogFileName = XxlJobFileAppender.makeLogFileName(
+                    new Date(logRequest.getLogDateTime()), logRequest.getJobId());
+            if (new java.io.File(newLogFileName).exists()) {
+                LogData logResult = XxlJobFileAppender.readLogByLogId(
+                        newLogFileName, logRequest.getLogId(), logRequest.getFromLineNum());
+                return Response.ofSuccess(logResult);
+            }
+        }
 
-        LogData logResult = XxlJobFileAppender.readLog(logFileName, logRequest.getFromLineNum());
+        // fallback to legacy format: logPath/yyyy-MM-dd/logId.log
+        String legacyLogFileName = XxlJobFileAppender.makeLogFileNameLegacy(
+                new Date(logRequest.getLogDateTime()), logRequest.getLogId());
+        LogData logResult = XxlJobFileAppender.readLog(legacyLogFileName, logRequest.getFromLineNum());
         return Response.ofSuccess(logResult);
     }
 

--- a/xxl-job-core/src/main/java/com/xxl/job/core/thread/JobLogFileCleanThreadHelper.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/thread/JobLogFileCleanThreadHelper.java
@@ -84,6 +84,10 @@ public class JobLogFileCleanThreadHelper {
                         // check expired
                         Date expiredDate = DateTool.addDays(logFileCreateDate, logRetentionDays);
                         if (todayDate.getTime() > expiredDate.getTime()) {
+                            // safety check: skip if file was recently written (long-running task may still be logging)
+                            if (System.currentTimeMillis() - childFile.lastModified() < 3600_000) {
+                                continue;
+                            }
                             // expired, remove all log of this day
                             FileTool.delete(childFile);
                             //FileUtil.deleteRecursively(childFile);

--- a/xxl-job-core/src/main/java/com/xxl/job/core/thread/JobThread.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/thread/JobThread.java
@@ -109,8 +109,12 @@ public class JobThread extends Thread{
 					idleTimes = 0;
 					triggerLogIdSet.remove(triggerParam.getLogId());
 
-					// log filename, like "logPath/yyyy-MM-dd/9999.log"
-					String logFileName = XxlJobFileAppender.makeLogFileName(new Date(triggerParam.getLogDateTime()), triggerParam.getLogId());
+					// log filename, like "logPath/yyyy-MM-dd/job-7.log"
+					String logFileName = XxlJobFileAppender.makeLogFileName(new Date(triggerParam.getLogDateTime()), triggerParam.getJobId());
+
+					// write START marker and index entry
+					XxlJobFileAppender.appendLogStart(logFileName, triggerParam.getLogId());
+
 					XxlJobContext xxlJobContext = new XxlJobContext(
 							triggerParam.getJobId(),
 							triggerParam.getExecutorParams(),
@@ -199,12 +203,20 @@ public class JobThread extends Thread{
 				XxlJobHelper.log("<br>----------- JobThread Exception:" + errorMsg + "<br>----------- xxl-job job execute end(error) -----------");
 			} finally {
                 if(triggerParam != null) {
+                    // write END marker
+                    String logFileName = XxlJobContext.getXxlJobContext() != null
+                            ? XxlJobContext.getXxlJobContext().getLogFileName() : null;
+                    if (logFileName != null) {
+                        XxlJobFileAppender.appendLogEnd(logFileName, triggerParam.getLogId());
+                    }
+
                     // callback handler info
                     if (!toStop) {
                         // common
                         XxlJobExecutor.getInstance().getTriggerCallbackThreadHelper().pushCallBack(new CallbackData(
                         		triggerParam.getLogId(),
 								triggerParam.getLogDateTime(),
+								triggerParam.getJobId(),
 								XxlJobContext.getXxlJobContext().getHandleCode(),
 								XxlJobContext.getXxlJobContext().getHandleMsg() )
 						);
@@ -213,6 +225,7 @@ public class JobThread extends Thread{
 						XxlJobExecutor.getInstance().getTriggerCallbackThreadHelper().pushCallBack(new CallbackData(
                         		triggerParam.getLogId(),
 								triggerParam.getLogDateTime(),
+								triggerParam.getJobId(),
 								XxlJobContext.HANDLE_CODE_FAIL,
 								stopReason + " [job running, killed]" )
 						);
@@ -229,6 +242,7 @@ public class JobThread extends Thread{
 				XxlJobExecutor.getInstance().getTriggerCallbackThreadHelper().pushCallBack(new CallbackData(
 						triggerParam.getLogId(),
 						triggerParam.getLogDateTime(),
+						triggerParam.getJobId(),
 						XxlJobContext.HANDLE_CODE_FAIL,
 						stopReason + " [job not executed, in the job queue, killed.]")
 				);

--- a/xxl-job-core/src/main/java/com/xxl/job/core/thread/TriggerCallbackThreadHelper.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/thread/TriggerCallbackThreadHelper.java
@@ -184,7 +184,18 @@ public class TriggerCallbackThreadHelper {
      */
     private void appendCallbackResult(List<CallbackData> callbackParamList, String logContent){
         for (CallbackData callbackParam: callbackParamList) {
-            String logFileName = XxlJobFileAppender.makeLogFileName(new Date(callbackParam.getLogDateTime()), callbackParam.getLogId());
+            // determine log file: prefer new merged format, fallback to legacy
+            String logFileName;
+            if (callbackParam.getJobId() > 0) {
+                logFileName = XxlJobFileAppender.makeLogFileName(new Date(callbackParam.getLogDateTime()), callbackParam.getJobId());
+            } else {
+                logFileName = XxlJobFileAppender.makeLogFileNameLegacy(new Date(callbackParam.getLogDateTime()), callbackParam.getLogId());
+                // for legacy format, only write if file already exists
+                if (!new java.io.File(logFileName).exists()) {
+                    continue;
+                }
+            }
+
             XxlJobContext.setXxlJobContext(new XxlJobContext(
                     -1,
                     null,

--- a/xxl-job-executor-samples/xxl-job-executor-sample-springboot-ai/src/main/java/com/xxl/job/executor/config/XxlJobConfig.java
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-springboot-ai/src/main/java/com/xxl/job/executor/config/XxlJobConfig.java
@@ -52,6 +52,9 @@ public class XxlJobConfig {
     @Value("${xxl.job.executor.glueenabled:true}")
     private Boolean glueEnabled;
 
+    @Value("${xxl.job.executor.logIsolatedByAddress:false}")
+    private Boolean logIsolatedByAddress;
+
     @Bean
     public XxlJobSpringExecutor xxlJobExecutor() {
         logger.info(">>>>>>>>>>> xxl-job config init.");
@@ -68,6 +71,7 @@ public class XxlJobConfig {
         xxlJobSpringExecutor.setLogRetentionDays(logRetentionDays);
         xxlJobSpringExecutor.setExcludedPackage(excludedPackage);
         xxlJobSpringExecutor.setGlueEnabled(glueEnabled);
+        xxlJobSpringExecutor.setLogIsolatedByAddress(logIsolatedByAddress);
 
         return xxlJobSpringExecutor;
     }

--- a/xxl-job-executor-samples/xxl-job-executor-sample-springboot/src/main/java/com/xxl/job/executor/config/XxlJobConfig.java
+++ b/xxl-job-executor-samples/xxl-job-executor-sample-springboot/src/main/java/com/xxl/job/executor/config/XxlJobConfig.java
@@ -52,6 +52,9 @@ public class XxlJobConfig {
     @Value("${xxl.job.executor.glueenabled:true}")
     private Boolean glueEnabled;
 
+    @Value("${xxl.job.executor.logIsolatedByAddress:false}")
+    private Boolean logIsolatedByAddress;
+
 
     @Bean
     public XxlJobSpringExecutor xxlJobExecutor() {
@@ -69,6 +72,7 @@ public class XxlJobConfig {
         xxlJobSpringExecutor.setLogRetentionDays(logRetentionDays);
         xxlJobSpringExecutor.setExcludedPackage(excludedPackage);
         xxlJobSpringExecutor.setGlueEnabled(glueEnabled);
+        xxlJobSpringExecutor.setLogIsolatedByAddress(logIsolatedByAddress);
 
         return xxlJobSpringExecutor;
     }


### PR DESCRIPTION
- 日志文件组织从每次执行一个文件(logId.log)改为每Job每天一个文件(job-{jobId}.log)
- 新增 .idx 索引文件，支持按字节偏移量快速定位日志段
- 使用 START/END 标记分隔合并文件中的不同执行日志段
- END 标记后继续读取 callback 日志，保证回调信息不丢失
- 新旧格式兼容：优先读取新格式，回退到旧格式 logId.log
- 新增 logIsolatedByAddress 配置，支持多Pod共享PVC场景下按地址隔离
- 日志清理增加 lastModified 安全检查，避免误删正在写入的文件
- LogRequest 和 CallbackData 新增 jobId 字段用于文件路由

**What kind of change does this PR introduce?** (check at least one)

- [x] Feature

**The description of the PR:**

https://github.com/xuxueli/xxl-job/issues/3429

**Other information:**

<img width="271" height="187" alt="image" src="https://github.com/user-attachments/assets/a8dd74e8-3d70-493f-8645-8e4d3af0dcd7" />
<img width="1363" height="327" alt="image" src="https://github.com/user-attachments/assets/abd0c4dd-17ab-4938-9745-ab6176936607" />
<img width="191" height="101" alt="image" src="https://github.com/user-attachments/assets/844d43e1-92d9-4f00-ab61-0a32923a5d42" />
